### PR TITLE
Simplified bounds moving from excessive use of `std::ops` to `Num`

### DIFF
--- a/filters/src/filter/classify/schmitt.rs
+++ b/filters/src/filter/classify/schmitt.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-use std::cmp::{PartialOrd, PartialEq};
+use std::cmp::PartialOrd;
 
 use signalo_traits::filter::Filter;
 
@@ -31,7 +31,7 @@ where
 impl<T, U> Filter<T> for Schmitt<T, U>
 where
     T: PartialOrd<T>,
-    U: Clone + PartialEq<U>,
+    U: Clone,
 {
     type Output = U;
 

--- a/filters/src/filter/convolve/mod.rs
+++ b/filters/src/filter/convolve/mod.rs
@@ -4,11 +4,10 @@
 
 //! Convolution filters.
 
-use std::ops::{Add, Mul, Div};
 use std::fmt;
 
 use arraydeque::{Array, ArrayDeque, Wrapping};
-use num_traits::Zero;
+use num_traits::Num;
 
 use signalo_traits::filter::Filter;
 
@@ -25,7 +24,7 @@ where
 
 impl<T, A> Convolve<A>
 where
-    T: Copy + PartialOrd + Zero,
+    T: Copy,
     A: Array<Item=T>,
 {
     /// Creates a new `Convolve` filter with given `coefficients`.
@@ -43,7 +42,7 @@ where
 
 impl<T, A> Convolve<A>
 where
-    T: Copy + PartialOrd + Zero + Div<T, Output = T>,
+    T: Copy + PartialOrd + Num,
     A: Array<Item=T>,
 {
     /// Creates a new `Convolve` filter with given `coefficients`, normalizing them.
@@ -76,7 +75,7 @@ where
 
 impl<T, A> Filter<T> for Convolve<A>
 where
-    T: Copy + Zero + Add<T, Output = T> + Mul<T, Output = T>,
+    T: Copy + Num,
     A: Array<Item = T>,
 {
     type Output = T;

--- a/filters/src/filter/kalman/mod.rs
+++ b/filters/src/filter/kalman/mod.rs
@@ -4,8 +4,6 @@
 
 //! Kalman filters.
 
-// use std::ops::{Sub, Add, Mul, Div};
-
 use num_traits::{Zero, One, Num};
 
 use signalo_traits::filter::Filter;

--- a/filters/src/filter/mean/exp/mean.rs
+++ b/filters/src/filter/mean/exp/mean.rs
@@ -4,9 +4,7 @@
 
 //! Exponential moving average filters.
 
-use std::ops::{Sub, Add, Mul, Div};
-
-use num_traits::{Zero, One};
+use num_traits::{Zero, One, Num};
 
 use signalo_traits::filter::Filter;
 
@@ -37,7 +35,7 @@ where
 
 impl<T> Filter<T> for Mean<T>
 where
-    T: Copy + Add<T, Output=T> + Sub<T, Output=T> + Mul<T, Output=T> + Div<T, Output=T>
+    T: Copy + Num,
 {
     type Output = T;
 

--- a/filters/src/filter/mean/mean.rs
+++ b/filters/src/filter/mean/mean.rs
@@ -4,12 +4,11 @@
 
 //! Moving average filters.
 
-use std::ops::{Sub, Add, Div};
 use std::fmt;
 
 use arraydeque::{Array, ArrayDeque, Wrapping};
 
-use num_traits::One;
+use num_traits::Num;
 
 use signalo_traits::filter::Filter;
 
@@ -40,7 +39,7 @@ where
 
 impl<T, A> Filter<T> for Mean<A>
 where
-    T: Copy + One + Add<T, Output=T> + Sub<T, Output=T> + Div<T, Output=T>,
+    T: Copy + Num,
     A: Array<Item=T>,
 {
     type Output = T;

--- a/filters/src/filter/median/exp/mod.rs
+++ b/filters/src/filter/median/exp/mod.rs
@@ -4,9 +4,7 @@
 
 //! Approximated exponential moving median filters.
 
-use std::ops::{Sub, Add, Mul, Div};
-
-use num_traits::{Zero, One};
+use num_traits::{Zero, One, Num};
 
 use signalo_traits::filter::Filter;
 
@@ -60,7 +58,7 @@ where
 
 impl<T> Filter<T> for Median<T>
 where
-    T: Copy + Add<T, Output=T> + Sub<T, Output=T> + Mul<T, Output=T> + Div<T, Output=T>
+    T: Copy + Num,
 {
     type Output = T;
 


### PR DESCRIPTION
Let's not leak implementations too much and use `T: Num` as bound for non-trivial filters