### PR TITLE
Update docs links

### DIFF
--- a/filters/Cargo.toml
+++ b/filters/Cargo.toml
@@ -8,8 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A collection of filters used in 'signalo' umbrella crate."
-documentation = "https://docs.rs/svm"
-homepage = "https://github.com/signalo/signalo/tree/master/filters"
+documentation = "https://docs.rs/signalo_filters"
 keywords = [
     "dsp",
     "digital-signal",
@@ -21,6 +20,7 @@ license = "MPL-2.0"
 name = "signalo_filters"
 readme = "README.md"
 repository = "https://github.com/signalo/signalo"
+homepage = "https://github.com/signalo/signalo/tree/master/filters"
 version = "0.5.1"
 
 [dependencies.arraydeque]

--- a/pipes/Cargo.toml
+++ b/pipes/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A collection of pipes used in 'signalo' umbrella crate."
-documentation = "https://docs.rs/svm"
+documentation = "https://docs.rs/signalo_pipes"
 keywords = [
     "dsp",
     "digital-signal",

--- a/signalo/Cargo.toml
+++ b/signalo/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A DSP toolbox with focus on embedded environments."
-documentation = "https://docs.rs/svm"
+documentation = "https://docs.rs/signalo"
 keywords = [
     "dsp",
     "digital-signal",

--- a/sinks/Cargo.toml
+++ b/sinks/Cargo.toml
@@ -8,8 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A collection of filters used in 'signalo' umbrella crate."
-documentation = "https://docs.rs/svm"
-homepage = "https://github.com/signalo/signalo/tree/master/filters"
+documentation = "https://docs.rs/signalo_sinks"
 keywords = [
     "dsp",
     "digital-signal",
@@ -21,6 +20,7 @@ license = "MPL-2.0"
 name = "signalo_sinks"
 readme = "README.md"
 repository = "https://github.com/signalo/signalo"
+homepage = "https://github.com/signalo/signalo/tree/master/filters"
 version = "0.5.1"
 
 [dependencies.num-traits]

--- a/sources/Cargo.toml
+++ b/sources/Cargo.toml
@@ -8,8 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A collection of filters used in 'signalo' umbrella crate."
-documentation = "https://docs.rs/svm"
-homepage = "https://github.com/signalo/signalo/tree/master/filters"
+documentation = "https://docs.rs/signalo_sources"
 keywords = [
     "dsp",
     "digital-signal",
@@ -21,6 +20,7 @@ license = "MPL-2.0"
 name = "signalo_sources"
 readme = "README.md"
 repository = "https://github.com/signalo/signalo"
+homepage = "https://github.com/signalo/signalo/tree/master/filters"
 version = "0.5.1"
 
 [dependencies.num-traits]

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -8,7 +8,7 @@ categories = [
     "algorithms",
 ]
 description = "A collection of traits used in 'signalo' umbrella crate."
-documentation = "https://docs.rs/svm"
+documentation = "https://docs.rs/signalo_traits"
 keywords = [
     "dsp",
     "digital-signal",


### PR DESCRIPTION
Update the links in `Cargo.toml` for each of the packages to point at their respective `docs.rs` pages. Also make the ordering of fields consistent across sub-crates.