### PR TITLE
Fix biquad filters

### DIFF
--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -237,4 +237,92 @@ mod tests {
 
         assert_nearly_eq!(output, input.to_vec(), 1e-6);
     }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_step_response_dc_gain() {
+        // DC gain = (b0 + b1 + b2) / (1 + a1 + a2)
+        // With b0=0.5, b1=0.25, b2=0.25, a1=0.0, a2=0.0 => DC gain = 1.0
+        let mut filter = Biquad::with_config(Config {
+            b0: 0.5_f64,
+            b1: 0.25,
+            b2: 0.25,
+            a1: 0.0,
+            a2: 0.0,
+        });
+
+        // Drive a step input long enough to reach steady state
+        let mut output = 0.0;
+
+        for _ in 0..1000 {
+            output = filter.filter(1.0);
+        }
+
+        let expected_dc_gain = (0.5 + 0.25 + 0.25) / (1.0 + 0.0 + 0.0);
+
+        assert_nearly_eq!(output, expected_dc_gain, 1e-6);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_impulse_response_matches_hand_computation() {
+        // Simple 1-pole IIR: b0=1, b1=0, b2=0, a1=-0.5, a2=0
+        // Impulse response: y[0]=1, y[1]=0.5, y[2]=0.25, ...
+        let mut filter = Biquad::with_config(Config {
+            b0: 1.0_f64,
+            b1: 0.0,
+            b2: 0.0,
+            a1: -0.5,
+            a2: 0.0,
+        });
+
+        let y0 = filter.filter(1.0);
+        let y1 = filter.filter(0.0);
+        let y2 = filter.filter(0.0);
+        let y3 = filter.filter(0.0);
+
+        assert_nearly_eq!(y0, 1.0, 1e-10);
+        assert_nearly_eq!(y1, 0.5, 1e-10);
+        assert_nearly_eq!(y2, 0.25, 1e-10);
+        assert_nearly_eq!(y3, 0.125, 1e-10);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_reset_clears_state() {
+        let config = Config {
+            b0: 1.0_f64,
+            b1: 0.5,
+            b2: 0.25,
+            a1: -0.3,
+            a2: 0.1,
+        };
+
+        let mut filter = Biquad::with_config(config.clone());
+
+        // Drive filter to accumulate non-zero state
+        for _ in 0..50 {
+            filter.filter(1.0);
+        }
+
+        // State should be non-zero now
+        {
+            let st = filter.state_mut();
+            #[allow(clippy::float_cmp)]
+            let state_is_nonzero = st.s1 != 0.0 || st.s2 != 0.0;
+            assert!(state_is_nonzero);
+        }
+
+        let mut filter = filter.reset();
+
+        {
+            let st = filter.state_mut();
+            assert_eq!(st.s1.to_bits(), 0.0_f64.to_bits());
+            assert_eq!(st.s2.to_bits(), 0.0_f64.to_bits());
+        }
+
+        // First output after reset should match a fresh filter
+        let mut fresh = Biquad::with_config(config);
+        assert_nearly_eq!(filter.filter(1.0), fresh.filter(1.0), 1e-10);
+    }
 }

--- a/src/filters/biquad.rs
+++ b/src/filters/biquad.rs
@@ -13,6 +13,10 @@
 //!
 //! This implementation uses the Direct Form II Transposed topology, which reduces
 //! sensitivity to coefficient quantization and avoids overflow in intermediate calculations.
+//!
+//! A filter is stable if and only if all poles lie strictly inside the unit circle, i.e.,
+//! the roots of `z^2 + a1*z + a2 = 0` have magnitude less than 1. Hand-crafted coefficients
+//! that violate this condition will produce diverging (unstable) output.
 
 use num_traits::Num;
 
@@ -54,9 +58,21 @@ pub struct Config<T> {
     pub a2: T,
 }
 
+impl<T> From<[T; 5]> for Config<T> {
+    fn from([b0, b1, b2, a1, a2]: [T; 5]) -> Self {
+        Self { b0, b1, b2, a1, a2 }
+    }
+}
+
+impl<T> From<Config<T>> for [T; 5] {
+    fn from(c: Config<T>) -> Self {
+        [c.b0, c.b1, c.b2, c.a1, c.a2]
+    }
+}
+
 impl<T> Default for Config<T>
 where
-    T: Clone + Num,
+    T: Num,
 {
     fn default() -> Self {
         Self {
@@ -82,7 +98,7 @@ pub struct State<T> {
 
 impl<T> Default for State<T>
 where
-    T: Clone + Num,
+    T: Num,
 {
     fn default() -> Self {
         Self {
@@ -138,7 +154,7 @@ impl<T> ConfigRef for Biquad<T> {
 
 impl<T> ConfigClone for Biquad<T>
 where
-    Config<T>: Clone,
+    T: Clone,
 {
     fn config(&self) -> Self::Config {
         self.config.clone()

--- a/src/filters/biquad/cascade.rs
+++ b/src/filters/biquad/cascade.rs
@@ -33,6 +33,20 @@ pub struct Config<T, const N: usize> {
     pub sections: [BiquadConfig<T>; N],
 }
 
+impl<T, const N: usize> From<[[T; 5]; N]> for Config<T, N> {
+    fn from(sections: [[T; 5]; N]) -> Self {
+        Self {
+            sections: sections.map(BiquadConfig::from),
+        }
+    }
+}
+
+impl<T, const N: usize> From<Config<T, N>> for [[T; 5]; N] {
+    fn from(c: Config<T, N>) -> Self {
+        c.sections.map(<[T; 5]>::from)
+    }
+}
+
 impl<T, const N: usize> Default for Config<T, N>
 where
     T: Clone + Num,
@@ -59,10 +73,7 @@ where
 {
     fn default() -> Self {
         Self {
-            sections: core::array::from_fn(|_| BiquadState {
-                s1: T::zero(),
-                s2: T::zero(),
-            }),
+            sections: core::array::from_fn(|_| BiquadState::default()),
         }
     }
 }
@@ -107,7 +118,7 @@ where
 
 impl<T, const N: usize> ConfigClone for BiquadCascade<T, N>
 where
-    Config<T, N>: Clone,
+    T: Clone,
 {
     fn config(&self) -> Self::Config {
         self.config.clone()

--- a/src/filters/biquad/cascade.rs
+++ b/src/filters/biquad/cascade.rs
@@ -225,21 +225,41 @@ mod tests {
     fn test_reset() {
         let config = Config {
             sections: [BiquadConfig {
-                b0: 1.0,
+                b0: 1.0_f64,
                 b1: 0.5,
-                b2: 0.0,
-                a1: 0.0,
-                a2: 0.0,
+                b2: 0.25,
+                a1: -0.3,
+                a2: 0.1,
             }],
         };
 
-        let mut filter = BiquadCascade::with_config(config);
-        let first_output = filter.filter(1.0);
+        let mut filter = BiquadCascade::with_config(config.clone());
 
-        let filter = filter.reset();
-        let mut filter = filter;
-        let after_reset = filter.filter(1.0);
-        assert_eq!(first_output, after_reset);
+        // Accumulate non-zero state
+        for _ in 0..50 {
+            filter.filter(1.0);
+        }
+
+        // State must be non-zero before reset
+        {
+            let st = filter.state_mut();
+            #[allow(clippy::float_cmp)]
+            let state_is_nonzero = st.sections[0].s1 != 0.0 || st.sections[0].s2 != 0.0;
+            assert!(state_is_nonzero);
+        }
+
+        let mut filter = filter.reset();
+
+        // State must be zero after reset
+        {
+            let st = filter.state_mut();
+            assert_eq!(st.sections[0].s1.to_bits(), 0.0_f64.to_bits());
+            assert_eq!(st.sections[0].s2.to_bits(), 0.0_f64.to_bits());
+        }
+
+        // First sample after reset matches a fresh filter
+        let mut fresh = BiquadCascade::with_config(config);
+        assert_nearly_eq!(filter.filter(1.0), fresh.filter(1.0), 1e-10);
     }
 
     #[test]
@@ -324,5 +344,42 @@ mod tests {
         let output: Vec<_> = input.iter().map(|&x| filter.filter(x)).collect();
 
         assert_nearly_eq!(output, input.to_vec(), 1e-6);
+    }
+
+    #[test]
+    fn test_two_stages_nonidentity() {
+        use super::super::Biquad;
+        use crate::traits::Filter;
+
+        // Two non-trivial stages: compare cascade output against two sequential Biquad filters
+        let cfg_a = BiquadConfig {
+            b0: 0.5_f64,
+            b1: 0.25,
+            b2: 0.0,
+            a1: -0.3,
+            a2: 0.0,
+        };
+        let cfg_b = BiquadConfig {
+            b0: 0.8_f64,
+            b1: 0.0,
+            b2: 0.1,
+            a1: 0.2,
+            a2: -0.05,
+        };
+
+        let mut cascade = BiquadCascade::with_config(Config {
+            sections: [cfg_a.clone(), cfg_b.clone()],
+        });
+
+        let mut biquad_a = Biquad::with_config(cfg_a);
+        let mut biquad_b = Biquad::with_config(cfg_b);
+
+        let input = [1.0, 0.0, -1.0, 0.5, 0.3, 0.0, 1.2, -0.7, 0.0, 0.1_f64];
+
+        for &x in &input {
+            let cascade_out = cascade.filter(x);
+            let sequential_out = biquad_b.filter(biquad_a.filter(x));
+            assert_nearly_eq!(cascade_out, sequential_out, 1e-12);
+        }
     }
 }

--- a/src/filters/biquad/coefficients.rs
+++ b/src/filters/biquad/coefficients.rs
@@ -70,6 +70,8 @@ impl Butterworth {
     /// Panics if `T` cannot represent the constants `PI`, `2.0`, or `√2`. This is infallible
     /// for standard `f32` and `f64` types.
     ///
+    /// In debug builds, panics if `sample_rate <= 0`, `freq <= 0`, or `freq >= sample_rate / 2`.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -82,6 +84,13 @@ impl Butterworth {
     #[cfg(feature = "std")]
     #[allow(clippy::unwrap_used)]
     pub fn lowpass<T: Float>(sample_rate: T, freq: T) -> [T; 5] {
+        debug_assert!(sample_rate > T::zero(), "sample_rate must be positive");
+        debug_assert!(freq > T::zero(), "freq must be positive");
+        debug_assert!(
+            freq < sample_rate / T::from(2.0).unwrap(),
+            "freq must be below Nyquist (sample_rate / 2)"
+        );
+
         let (pi, two, sqrt2) = float_constants::<T>();
 
         let omega = two * pi * freq / sample_rate;
@@ -114,6 +123,8 @@ impl Butterworth {
     /// Panics if `T` cannot represent the constants `PI`, `2.0`, or `√2`. This is infallible
     /// for standard `f32` and `f64` types.
     ///
+    /// In debug builds, panics if `sample_rate <= 0`, `freq <= 0`, or `freq >= sample_rate / 2`.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -126,6 +137,13 @@ impl Butterworth {
     #[cfg(feature = "std")]
     #[allow(clippy::unwrap_used)]
     pub fn highpass<T: Float>(sample_rate: T, freq: T) -> [T; 5] {
+        debug_assert!(sample_rate > T::zero(), "sample_rate must be positive");
+        debug_assert!(freq > T::zero(), "freq must be positive");
+        debug_assert!(
+            freq < sample_rate / T::from(2.0).unwrap(),
+            "freq must be below Nyquist (sample_rate / 2)"
+        );
+
         let (pi, two, sqrt2) = float_constants::<T>();
 
         let omega = two * pi * freq / sample_rate;
@@ -148,8 +166,8 @@ impl Butterworth {
         [b0 / a0, b1 / a0, b2 / a0, a1 / a0, a2 / a0]
     }
 
-    /// Compute Butterworth bandpass coefficients for a filter centered at `center` Hz with
-    /// quality factor `q`, given a `sample_rate` in Hz.
+    /// Compute bandpass coefficients for a filter centered at `center` Hz with quality factor `q`,
+    /// given a `sample_rate` in Hz.
     ///
     /// Implements the *constant 0 dB peak gain* variant from the Audio EQ Cookbook (`b0 = α`).
     /// For the constant skirt-gain variant (`b0 = Q·α`) use a different design.
@@ -160,6 +178,9 @@ impl Butterworth {
     ///
     /// Panics if `T` cannot represent the constants `PI` or `2.0`. This is infallible
     /// for standard `f32` and `f64` types.
+    ///
+    /// In debug builds, panics if `sample_rate <= 0`, `center <= 0`, `center >= sample_rate / 2`,
+    /// or `q <= 0`.
     ///
     /// # Examples
     ///
@@ -173,6 +194,14 @@ impl Butterworth {
     #[cfg(feature = "std")]
     #[allow(clippy::unwrap_used)]
     pub fn bandpass<T: Float>(sample_rate: T, center: T, q: T) -> [T; 5] {
+        debug_assert!(sample_rate > T::zero(), "sample_rate must be positive");
+        debug_assert!(center > T::zero(), "center must be positive");
+        debug_assert!(
+            center < sample_rate / T::from(2.0).unwrap(),
+            "center must be below Nyquist (sample_rate / 2)"
+        );
+        debug_assert!(q > T::zero(), "q must be positive");
+
         let (pi, two, _sqrt2) = float_constants::<T>();
 
         let omega = two * pi * center / sample_rate;
@@ -196,6 +225,9 @@ impl Butterworth {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "std")]
+    use std::vec::Vec;
+
     #[cfg(feature = "std")]
     use nearly_eq::assert_nearly_eq;
 
@@ -328,5 +360,151 @@ mod tests {
         let gain = num_re.hypot(num_im) / den_re.hypot(den_im);
 
         assert_nearly_eq!(gain, 1.0_f64 / 2.0_f64.sqrt(), 1e-10);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_butterworth_lowpass_cutoff_gain_f32() {
+        let sample_rate = 44100.0f32;
+        let freq = 1000.0f32;
+        let [b0, b1, b2, a1, a2] = Butterworth::lowpass(sample_rate, freq);
+
+        let omega = 2.0f32 * std::f32::consts::PI * freq / sample_rate;
+        let (s, c) = omega.sin_cos();
+        let num_re = b0 + b1 * c + b2 * (c * c - s * s);
+        let num_im = -b1 * s + b2 * (-2.0 * s * c);
+        let den_re = 1.0 + a1 * c + a2 * (c * c - s * s);
+        let den_im = -a1 * s + a2 * (-2.0 * s * c);
+        let gain = num_re.hypot(num_im) / den_re.hypot(den_im);
+
+        assert_nearly_eq!(gain, 1.0f32 / 2.0f32.sqrt(), 1e-4);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_butterworth_highpass_cutoff_gain_f32() {
+        let sample_rate = 44100.0f32;
+        let freq = 1000.0f32;
+        let [b0, b1, b2, a1, a2] = Butterworth::highpass(sample_rate, freq);
+
+        let omega = 2.0f32 * std::f32::consts::PI * freq / sample_rate;
+        let (s, c) = omega.sin_cos();
+        let num_re = b0 + b1 * c + b2 * (c * c - s * s);
+        let num_im = -b1 * s + b2 * (-2.0 * s * c);
+        let den_re = 1.0 + a1 * c + a2 * (c * c - s * s);
+        let den_im = -a1 * s + a2 * (-2.0 * s * c);
+        let gain = num_re.hypot(num_im) / den_re.hypot(den_im);
+
+        assert_nearly_eq!(gain, 1.0f32 / 2.0f32.sqrt(), 1e-4);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_butterworth_bandpass_center_gain_f32() {
+        let sample_rate = 44100.0f32;
+        let center = 1000.0f32;
+        let q = 1.0f32;
+        let [b0, b1, b2, a1, a2] = Butterworth::bandpass(sample_rate, center, q);
+
+        let omega = 2.0f32 * std::f32::consts::PI * center / sample_rate;
+        let (s, c) = omega.sin_cos();
+        let num_re = b0 + b1 * c + b2 * (c * c - s * s);
+        let num_im = -b1 * s + b2 * (-2.0 * s * c);
+        let den_re = 1.0 + a1 * c + a2 * (c * c - s * s);
+        let den_im = -a1 * s + a2 * (-2.0 * s * c);
+        let gain = num_re.hypot(num_im) / den_re.hypot(den_im);
+
+        // Constant 0 dB peak gain bandpass has gain = 1.0 at center frequency
+        assert_nearly_eq!(gain, 1.0f32, 1e-4);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_lowpass_impulse_response_3db_cutoff() {
+        use crate::filters::biquad::{Biquad, Config};
+        use crate::traits::{Filter, WithConfig};
+
+        let sample_rate = 44100.0f64;
+        let freq = 1000.0;
+        let coeffs = Butterworth::lowpass(sample_rate, freq);
+        let [b0, b1, b2, a1, a2] = coeffs;
+
+        let mut filter = Biquad::with_config(Config { b0, b1, b2, a1, a2 });
+
+        // Drive an impulse and accumulate the frequency response via DFT at cutoff
+        let n = 4096usize;
+        let mut response: Vec<f64> = Vec::with_capacity(n);
+        response.push(filter.filter(1.0));
+
+        for _ in 1..n {
+            response.push(filter.filter(0.0));
+        }
+
+        // Evaluate DFT at freq bin corresponding to cutoff
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let (re, im) = {
+            let n_f = n as f64;
+            let k = (freq / sample_rate * n_f).round() as usize;
+            let k_f = k as f64;
+            response
+                .iter()
+                .enumerate()
+                .fold((0.0f64, 0.0f64), |(re, im), (i, &h)| {
+                    let angle = -2.0 * std::f64::consts::PI * k_f * (i as f64) / n_f;
+                    (re + h * angle.cos(), im + h * angle.sin())
+                })
+        };
+
+        let gain = re.hypot(im);
+
+        assert_nearly_eq!(gain, 1.0 / 2.0f64.sqrt(), 1e-3);
+    }
+
+    #[test]
+    #[cfg(feature = "std")]
+    fn test_highpass_impulse_response_3db_cutoff() {
+        use crate::filters::biquad::{Biquad, Config};
+        use crate::traits::{Filter, WithConfig};
+
+        let sample_rate = 44100.0f64;
+        let freq = 1000.0;
+        let coeffs = Butterworth::highpass(sample_rate, freq);
+        let [b0, b1, b2, a1, a2] = coeffs;
+
+        let mut filter = Biquad::with_config(Config { b0, b1, b2, a1, a2 });
+
+        let n = 4096usize;
+        let mut response: Vec<f64> = Vec::with_capacity(n);
+        response.push(filter.filter(1.0));
+
+        for _ in 1..n {
+            response.push(filter.filter(0.0));
+        }
+
+        #[allow(
+            clippy::cast_precision_loss,
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss
+        )]
+        let (re, im) = {
+            let n_f = n as f64;
+            let k = (freq / sample_rate * n_f).round() as usize;
+            let k_f = k as f64;
+            response
+                .iter()
+                .enumerate()
+                .fold((0.0f64, 0.0f64), |(re, im), (i, &h)| {
+                    let angle = -2.0 * std::f64::consts::PI * k_f * (i as f64) / n_f;
+                    (re + h * angle.cos(), im + h * angle.sin())
+                })
+        };
+
+        let gain = re.hypot(im);
+
+        assert_nearly_eq!(gain, 1.0 / 2.0f64.sqrt(), 1e-3);
     }
 }

--- a/src/filters/biquad/coefficients.rs
+++ b/src/filters/biquad/coefficients.rs
@@ -18,6 +18,9 @@
 //! - `[3]` = a1 (feedback denominator)
 //! - `[4]` = a2 (feedback denominator)
 //!
+//! This layout matches the field order of [`super::Config`] and supports direct conversion via
+//! `Config::from([b0, b1, b2, a1, a2])`.
+//!
 //! These coefficients are used in the biquad difference equation:
 //! ```text
 //! y[n] = b0*x[n] + b1*x[n-1] + b2*x[n-2] - a1*y[n-1] - a2*y[n-2]
@@ -43,7 +46,7 @@ use num_traits::Float;
 fn float_constants<T: Float>() -> (T, T, T) {
     let pi = T::from(core::f64::consts::PI).unwrap();
     let two = T::from(2.0).unwrap();
-    let sqrt2 = T::from(2.0_f64.sqrt()).unwrap();
+    let sqrt2 = T::from(2.0).unwrap().sqrt();
     (pi, two, sqrt2)
 }
 
@@ -202,7 +205,7 @@ impl Butterworth {
         );
         debug_assert!(q > T::zero(), "q must be positive");
 
-        let (pi, two, _sqrt2) = float_constants::<T>();
+        let (pi, two, _) = float_constants::<T>();
 
         let omega = two * pi * center / sample_rate;
         let sin_omega = omega.sin();
@@ -254,9 +257,9 @@ mod tests {
     #[test]
     #[cfg(feature = "std")]
     fn test_butterworth_highpass_nyquist_gain() {
-        // Butterworth highpass at Nyquist / 2 should have high frequency gain ≈ 1.0
+        // Butterworth highpass at Nyquist / 2 (i.e. sr / 4) should have high-frequency gain ≈ 1.0
         let sample_rate = 44100.0f64;
-        let freq = sample_rate / 4.0; // Nyquist / 2
+        let freq = sample_rate / 4.0; // Nyquist / 2 = sample_rate / 4
 
         let coeffs = Butterworth::highpass(sample_rate, freq);
         let [b0, b1, b2, a1, a2] = coeffs;

--- a/src/filters/biquad/coefficients.rs
+++ b/src/filters/biquad/coefficients.rs
@@ -52,8 +52,11 @@ fn float_constants<T: Float>() -> (T, T, T) {
 
 /// Butterworth filter coefficient calculator.
 ///
-/// Provides design equations for Butterworth lowpass, highpass, and bandpass
+/// Provides design equations for Butterworth lowpass, highpass, and cookbook bandpass
 /// biquad filter coefficients using standard DSP formulae.
+///
+/// All methods take `(sample_rate, frequency[, q])` in that order — sample rate first,
+/// then the characteristic frequency. This matches the convention of most DSP textbooks.
 ///
 /// # Requirements
 ///


### PR DESCRIPTION
- Strengthen biquad tests, add precondition `debug_assert!`s, and fix `cascade.rs` test module cfg
- Add `From<[T; 5]>` conversions, drop redundant bounds, and polish docs in biquad modules
- Fix `sqrt2` precision, drop unused `_sqrt2` in `bandpass`, and document argument order