### PR TITLE
Add complex input with real taps support to FIR convolve 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,8 @@ jobs:
         run: cargo test
       - name: Run `cargo test` [libm]
         run: cargo test --no-default-features --features "libm"
+      - name: Run `cargo test` [std, complex]
+        run: cargo test --features "complex"
 
   fmt:
     name: Rustfmt

--- a/src/filters/fir/convolve.rs
+++ b/src/filters/fir/convolve.rs
@@ -77,6 +77,10 @@ pub struct State<R> {
 ///
 /// Prefer the concrete aliases for common use:
 /// - [`ConvolveArray<T, N>`] — stack-allocated, `no_std`-friendly.
+#[cfg_attr(
+    feature = "complex",
+    doc = "- [`ConvolveArray<Complex32, N, f32>`](ConvolveArray) — complex IQ samples with real taps."
+)]
 /// - [`ConvolveVec<T>`] — heap-allocated, requires the `alloc` feature.
 #[derive(Clone, Debug)]
 pub struct Convolve<T, C, R, K = T> {
@@ -201,6 +205,7 @@ impl<T, C, R, K> StateTrait for Convolve<T, C, R, K> {
 impl<T, const N: usize, K> WithConfig for ConvolveArray<T, N, K>
 where
     T: Num,
+    K: Num,
 {
     type Output = Self;
 
@@ -273,6 +278,7 @@ impl<T, C, R, K> IntoGuts for Convolve<T, C, R, K> {
 impl<T, const N: usize, K> Reset for ConvolveArray<T, N, K>
 where
     T: Num,
+    K: Num,
 {
     fn reset(self) -> Self {
         Self::with_config(self.config)


### PR DESCRIPTION
Support a common SDR operation: filtering complex IQ baseband samples with real-valued FIR taps.

Generalize FIR convolution over coefficient type `K` while keeping existing API names and defaults.
To preserve API compatibility, `K` is added last after `const N: usize` on aliases like `ConvolveArray<T, N, K = T>`.
Keep `Filter<T>::Output` as `T` by requiring `sample * coefficient` to produce the sample type.

Filtering now only requires `Zero`, `Add`, and `Mul`; construction/reset keep `Num` because zero-filled state uses it.

Expose `num-complex` behind opt-in `complex` and add `"software-defined-radio"` and `"sdr"` keywords to the package.

Example:
```rust
let h = [0.5_f32, -0.25, 0.125, 0.0625];
let mut filt = ConvolveArray::<Complex32, 4, f32>::with_config(Config { h });
// ...
let complex_output = filt.filter(Complex32::new(real, imag));
```

Fixes https://github.com/signalo/signalo/issues/166.