### PR TITLE
PFB polyphase filter bank

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signalo"
 description = "A DSP toolbox with focus on embedded environments."
 categories = ["no-std", "embedded", "multimedia", "science", "algorithms"]
-keywords = ["dsp", "digital-signal", "signal-processing", "filters", "pipeline"]
+keywords = ["dsp", "digital-signal", "signal-processing", "filters", "pipeline", "software-defined-radio", "sdr"]
 readme = "README.md"
 license = "MPL-2.0"
 repository = "https://github.com/signalo/signalo"
@@ -15,6 +15,7 @@ circular-buffer = { version = "2.0.0", default-features = false }
 dimensioned = { version = "0.8", optional = true, default-features = false }
 guts = { version = "0.2.0", default-features = false }
 libm = { version = "0.2.16", optional = true, default-features = false }
+num-complex = { version = "0.4", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 replace_with = { version = "0.1.5", default-features = false }
 
@@ -25,12 +26,14 @@ droptest = "0.2.1"
 [features]
 default = ["std"]
 alloc = ["circular-buffer/alloc"]
-libm = ["dep:libm", "num-traits/libm"]
+complex = ["dep:num-complex"]
+libm = ["dep:libm", "num-complex?/libm", "num-traits/libm"]
 std = [
     "alloc",
     "guts/std",
     "replace_with/std",
     "circular-buffer/std",
+    "num-complex?/std",
     "num-traits/std",
     "dimensioned?/std",
 ]

--- a/src/filters/fir.rs
+++ b/src/filters/fir.rs
@@ -45,5 +45,6 @@ pub mod convolve;
 pub mod differentiate;
 pub mod mean;
 pub mod mean_variance;
+pub mod polyphase;
 pub mod savitzky_golay;
 pub mod window;

--- a/src/filters/fir/convolve.rs
+++ b/src/filters/fir/convolve.rs
@@ -5,9 +5,10 @@
 //! Convolution filters.
 
 use core::marker::PhantomData;
+use core::ops::{Add, Mul};
 
 use circular_buffer::{CircularBuffer, FixedCircularBuffer};
-use num_traits::Num;
+use num_traits::{Num, Zero};
 
 use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
 use crate::traits::{
@@ -29,7 +30,7 @@ pub mod windowed_sinc;
 
 /// The convolution filter's configuration.
 ///
-/// Holds the coefficient storage `C`, which must implement [`AsSlice<T>`]
+/// Holds the coefficient storage `C`, which must implement [`AsSlice<K>`]
 /// on relevant impls. Use [`ConvolveArray`] for stack-allocated coefficients
 /// or [`ConvolveVec`] for heap-allocated ones.
 #[derive(Clone, Debug)]
@@ -48,7 +49,8 @@ pub struct State<R> {
     pub taps: R,
 }
 
-/// A convolution filter generic over coefficient storage `C` and tap storage `R`.
+/// A convolution filter generic over sample type `T`, coefficient storage `C`,
+/// tap storage `R`, and coefficient type `K`.
 ///
 /// # Coefficient ordering
 ///
@@ -77,10 +79,10 @@ pub struct State<R> {
 /// - [`ConvolveArray<T, N>`] — stack-allocated, `no_std`-friendly.
 /// - [`ConvolveVec<T>`] — heap-allocated, requires the `alloc` feature.
 #[derive(Clone, Debug)]
-pub struct Convolve<T, C, R> {
+pub struct Convolve<T, C, R, K = T> {
     config: Config<C>,
     state: State<R>,
-    _pd: PhantomData<T>,
+    _pd: PhantomData<(T, K)>,
 }
 
 /// A convolution filter backed by a const-generic array of coefficients and a
@@ -88,7 +90,8 @@ pub struct Convolve<T, C, R> {
 ///
 /// This alias is the `no_std`-friendly, zero-allocation form. Both the
 /// coefficient array and the tap ring-buffer live entirely on the stack.
-pub type ConvolveArray<T, const N: usize> = Convolve<T, [T; N], FixedCircularBuffer<T, N>>;
+pub type ConvolveArray<T, const N: usize, K = T> =
+    Convolve<T, [K; N], FixedCircularBuffer<T, N>, K>;
 
 /// A convolution filter backed by heap-allocated [`Vec`](alloc::vec::Vec) coefficients
 /// and a [`HeapCircularBuffer`] tap buffer.
@@ -97,20 +100,20 @@ pub type ConvolveArray<T, const N: usize> = Convolve<T, [T; N], FixedCircularBuf
 /// this variant, since the tap buffer cannot be `Default`-constructed without
 /// knowing the desired capacity at compile time.
 #[cfg(feature = "alloc")]
-pub type ConvolveVec<T> = Convolve<T, alloc::vec::Vec<T>, HeapCircularBuffer<T>>;
+pub type ConvolveVec<T, K = T> = Convolve<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
 
 /// A convolution filter that borrows a [`CircularBuffer`] tap buffer.
 ///
 /// This alias allows sharing a caller-owned ring buffer without taking
 /// ownership of it. The coefficient storage `C` remains generic — use
-/// any type implementing [`AsSlice<T>`](crate::storage::AsSlice).
+/// any type implementing [`AsSlice<K>`](crate::storage::AsSlice).
 /// Construct via [`Convolve::from_parts`], passing
 /// a `&mut CircularBuffer<T>` for the tap buffer.
-pub type ConvolveRefMut<'a, T, C> = Convolve<T, C, &'a mut CircularBuffer<T>>;
+pub type ConvolveRefMut<'a, T, C, K = T> = Convolve<T, C, &'a mut CircularBuffer<T>, K>;
 
-impl<T, C, R> Convolve<T, C, R>
+impl<T, C, R, K> Convolve<T, C, R, K>
 where
-    C: AsSlice<T>,
+    C: AsSlice<K>,
     R: RingBuffer<T>,
 {
     /// Creates a [`Convolve`] filter from an already-constructed `config` and
@@ -187,15 +190,15 @@ where
     }
 }
 
-impl<T, C, R> ConfigTrait for Convolve<T, C, R> {
+impl<T, C, R, K> ConfigTrait for Convolve<T, C, R, K> {
     type Config = Config<C>;
 }
 
-impl<T, C, R> StateTrait for Convolve<T, C, R> {
+impl<T, C, R, K> StateTrait for Convolve<T, C, R, K> {
     type State = State<R>;
 }
 
-impl<T, const N: usize> WithConfig for ConvolveArray<T, N>
+impl<T, const N: usize, K> WithConfig for ConvolveArray<T, N, K>
 where
     T: Num,
 {
@@ -225,13 +228,13 @@ where
     }
 }
 
-impl<T, C, R> ConfigRef for Convolve<T, C, R> {
+impl<T, C, R, K> ConfigRef for Convolve<T, C, R, K> {
     fn config_ref(&self) -> &Self::Config {
         &self.config
     }
 }
 
-impl<T, C, R> ConfigClone for Convolve<T, C, R>
+impl<T, C, R, K> ConfigClone for Convolve<T, C, R, K>
 where
     Config<C>: Clone,
 {
@@ -240,17 +243,17 @@ where
     }
 }
 
-impl<T, C, R> StateMut for Convolve<T, C, R> {
+impl<T, C, R, K> StateMut for Convolve<T, C, R, K> {
     fn state_mut(&mut self) -> &mut Self::State {
         &mut self.state
     }
 }
 
-impl<T, C, R> HasGuts for Convolve<T, C, R> {
+impl<T, C, R, K> HasGuts for Convolve<T, C, R, K> {
     type Guts = (Config<C>, State<R>);
 }
 
-impl<T, C, R> FromGuts for Convolve<T, C, R> {
+impl<T, C, R, K> FromGuts for Convolve<T, C, R, K> {
     fn from_guts(guts: Self::Guts) -> Self {
         let (config, state) = guts;
         Self {
@@ -261,13 +264,13 @@ impl<T, C, R> FromGuts for Convolve<T, C, R> {
     }
 }
 
-impl<T, C, R> IntoGuts for Convolve<T, C, R> {
+impl<T, C, R, K> IntoGuts for Convolve<T, C, R, K> {
     fn into_guts(self) -> Self::Guts {
         (self.config, self.state)
     }
 }
 
-impl<T, const N: usize> Reset for ConvolveArray<T, N>
+impl<T, const N: usize, K> Reset for ConvolveArray<T, N, K>
 where
     T: Num,
 {
@@ -277,12 +280,13 @@ where
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize> ResetMut for ConvolveArray<T, N> where Self: Reset {}
+impl<T, const N: usize, K> ResetMut for ConvolveArray<T, N, K> where Self: Reset {}
 
-impl<T, C, R> Filter<T> for Convolve<T, C, R>
+impl<T, C, R, K> Filter<T> for Convolve<T, C, R, K>
 where
-    T: Clone + Num,
-    C: AsSlice<T>,
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: AsSlice<K>,
     R: RingBuffer<T>,
 {
     type Output = T;
@@ -298,7 +302,7 @@ where
         state_iter
             .zip(coeff_iter)
             .fold(T::zero(), |sum, (state, coeff)| {
-                sum + (state.clone() * coeff.clone())
+                sum + ((*state).clone() * (*coeff).clone())
             })
     }
 }

--- a/src/filters/fir/convolve/tests.rs
+++ b/src/filters/fir/convolve/tests.rs
@@ -106,6 +106,30 @@ fn integer_convolution() {
     assert_eq!(filter2.filter(2), 3);
 }
 
+#[cfg(feature = "complex")]
+#[test]
+fn real_taps_complex_samples_match_independent_real_filters() {
+    use crate::complex::Complex32;
+
+    let coefficients = [0.5_f32, -0.25, 0.125, 0.0625];
+    let real_input = [1.0_f32, -2.0, 3.0, 5.0, -8.0, 13.0, -21.0];
+    let imag_input = [34.0_f32, -55.0, 89.0, -144.0, 233.0, -377.0, 610.0];
+
+    let mut real_filter = ConvolveArray::<f32, 4>::with_config(Config { coefficients });
+    let mut imag_filter = ConvolveArray::<f32, 4>::with_config(Config { coefficients });
+    let mut complex_filter =
+        ConvolveArray::<Complex32, 4, f32>::with_config(Config { coefficients });
+
+    for (&real, &imag) in real_input.iter().zip(&imag_input) {
+        let real_output = real_filter.filter(real);
+        let imag_output = imag_filter.filter(imag);
+        let complex_output = complex_filter.filter(Complex32::new(real, imag));
+
+        assert_abs_diff_eq!(complex_output.re, real_output, epsilon = 1e-6);
+        assert_abs_diff_eq!(complex_output.im, imag_output, epsilon = 1e-6);
+    }
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[test]
 #[should_panic(expected = "denominator magnitude")]

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR filter banks, executors, and multirate filters.
+
+pub mod polyphase_filter_bank;

--- a/src/filters/fir/polyphase/polyphase_filter_bank.rs
+++ b/src/filters/fir/polyphase/polyphase_filter_bank.rs
@@ -1,0 +1,398 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR filter bank.
+
+use core::ops::{Add, Mul};
+
+use num_traits::Zero;
+
+use crate::storage::AsSlice;
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, Reset, WithConfig,
+};
+
+/// The polyphase filter bank's configuration.
+///
+/// Holds the phase-major coefficient storage `C`, which must implement
+/// [`AsSlice<K>`] on relevant impls. Use [`PolyphaseFilterBankArray`] for
+/// stack-allocated coefficients, `PolyphaseFilterBankVec` for heap-allocated
+/// coefficients, or [`PolyphaseFilterBankRefMut`] for caller-owned coefficient
+/// storage.
+#[derive(Clone, Debug)]
+pub struct Config<C> {
+    /// Number of polyphase branches.
+    pub num_phases: usize,
+    /// Number of coefficients in each phase branch.
+    pub taps_per_phase: usize,
+    /// Phase-major coefficients in normal FIR order within each phase.
+    ///
+    /// For phase `p`, the phase coefficient slice is:
+    ///
+    /// ```text
+    /// coefficients[p * taps_per_phase .. (p + 1) * taps_per_phase]
+    /// ```
+    pub coefficients: C,
+}
+
+/// A polyphase FIR filter bank.
+///
+/// This type stores phase coefficients and can evaluate a selected phase against
+/// caller-provided sample history. It does not own input history, advance time,
+/// or implement rate conversion by itself. Stateful users such as rational
+/// resamplers own delay lines and use [`Self::execute`] to evaluate selected
+/// phases.
+///
+/// # Coefficient ordering
+///
+/// Coefficients are stored phase-major in normal FIR order within each phase:
+///
+/// ```text
+/// phase p: h[p], h[p + P], h[p + 2P], ...
+/// ```
+///
+/// where `P = num_phases`. [`Self::execute`] accepts sample history in
+/// oldest-to-newest order and pairs `h[p]` with the newest sample, matching
+/// normal FIR convolution coefficient semantics.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`PolyphaseFilterBankArray<K, N>`] — stack-allocated, `no_std`-friendly.
+/// - `PolyphaseFilterBankVec<K>` — heap-allocated, requires the `alloc` feature.
+/// - [`PolyphaseFilterBankRefMut<'_, K>`] — caller-owned coefficient storage.
+#[derive(Clone, Debug)]
+pub struct PolyphaseFilterBank<C> {
+    config: Config<C>,
+}
+
+/// A polyphase filter bank backed by a const-generic coefficient array.
+pub type PolyphaseFilterBankArray<K, const N: usize> = PolyphaseFilterBank<[K; N]>;
+
+/// A polyphase filter bank backed by heap-allocated coefficients.
+#[cfg(feature = "alloc")]
+pub type PolyphaseFilterBankVec<K> = PolyphaseFilterBank<alloc::vec::Vec<K>>;
+
+/// A polyphase filter bank that borrows caller-owned coefficient storage.
+pub type PolyphaseFilterBankRefMut<'a, K> = PolyphaseFilterBank<&'a mut [K]>;
+
+impl<C> PolyphaseFilterBank<C> {
+    /// Creates a [`PolyphaseFilterBank`] from pre-arranged phase-major
+    /// coefficients.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_phases` or `taps_per_phase` is zero, or if
+    /// `coefficients.len() != num_phases * taps_per_phase`.
+    pub fn from_parts<K>(config: Config<C>) -> Self
+    where
+        C: AsSlice<K>,
+    {
+        assert!(
+            config.num_phases > 0,
+            "PolyphaseFilterBank: number of phases must be > 0"
+        );
+        assert!(
+            config.taps_per_phase > 0,
+            "PolyphaseFilterBank: taps per phase must be > 0"
+        );
+
+        let Some(expected_taps) = config.num_phases.checked_mul(config.taps_per_phase) else {
+            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
+        };
+
+        assert_eq!(
+            config.coefficients.as_slice().len(),
+            expected_taps,
+            "PolyphaseFilterBank: coefficient count must equal num_phases * taps_per_phase"
+        );
+
+        Self { config }
+    }
+
+    /// Returns the number of polyphase branches.
+    #[must_use]
+    pub fn num_phases(&self) -> usize {
+        self.config.num_phases
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.config.taps_per_phase
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.num_phases() * self.taps_per_phase()
+    }
+
+    /// Returns the phase-major coefficient slice for `phase`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phase >= self.num_phases()`.
+    #[must_use]
+    pub fn phase_coefficients<K>(&self, phase: usize) -> &[K]
+    where
+        C: AsSlice<K>,
+    {
+        assert!(
+            phase < self.num_phases(),
+            "PolyphaseFilterBank: phase index out of range"
+        );
+
+        let start = phase * self.taps_per_phase();
+        let end = start + self.taps_per_phase();
+        &self.config.coefficients.as_slice()[start..end]
+    }
+
+    /// Evaluates `phase` against caller-provided sample history.
+    ///
+    /// The `taps` iterator must yield samples in oldest-to-newest order. Phase
+    /// coefficients are paired so the first coefficient in the selected phase,
+    /// `h[phase]`, multiplies the newest sample.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phase >= self.num_phases()`, or if the number of samples
+    /// yielded by `taps` does not equal `self.taps_per_phase()`.
+    #[must_use]
+    pub fn execute<'a, T, K, I>(&self, phase: usize, taps: I) -> T
+    where
+        T: 'a + Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+        K: Clone,
+        C: AsSlice<K>,
+        I: IntoIterator<Item = &'a T>,
+    {
+        let coefficients = self.phase_coefficients(phase);
+        let mut taps = taps.into_iter();
+        let mut count = 0;
+        let output =
+            taps.by_ref()
+                .zip(coefficients.iter().rev())
+                .fold(T::zero(), |sum, (state, coeff)| {
+                    count += 1;
+                    sum + ((*state).clone() * (*coeff).clone())
+                });
+
+        assert!(
+            count == self.taps_per_phase() && taps.next().is_none(),
+            "PolyphaseFilterBank: taps count must equal taps_per_phase"
+        );
+
+        output
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<K> PolyphaseFilterBankVec<K>
+where
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed filter bank from normal dense FIR prototype
+    /// coefficients.
+    ///
+    /// The prototype coefficients are interpreted as:
+    ///
+    /// ```text
+    /// h[0], h[1], ..., h[N - 1]
+    /// ```
+    ///
+    /// They are zero-padded as needed and copied into phase-major order:
+    ///
+    /// ```text
+    /// phase p: h[p], h[p + P], h[p + 2P], ...
+    /// ```
+    ///
+    /// where `P = num_phases`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_phases` is zero, `prototype` is empty, or the padded
+    /// coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(num_phases: usize, prototype: &[K]) -> Self {
+        assert!(
+            num_phases > 0,
+            "PolyphaseFilterBank: number of phases must be > 0"
+        );
+        assert!(
+            !prototype.is_empty(),
+            "PolyphaseFilterBank: tap count must be > 0"
+        );
+
+        let taps_per_phase = prototype.len().div_ceil(num_phases);
+        let Some(total_taps) = num_phases.checked_mul(taps_per_phase) else {
+            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
+        };
+
+        let mut coefficients = alloc::vec![K::zero(); total_taps];
+        for phase in 0..num_phases {
+            for tap in 0..taps_per_phase {
+                let src = tap * num_phases + phase;
+                if src < prototype.len() {
+                    let dst = phase * taps_per_phase + tap;
+                    coefficients[dst] = prototype[src].clone();
+                }
+            }
+        }
+
+        Self::from_parts(Config {
+            num_phases,
+            taps_per_phase,
+            coefficients,
+        })
+    }
+}
+
+impl<C> ConfigTrait for PolyphaseFilterBank<C> {
+    type Config = Config<C>;
+}
+
+impl<K, const N: usize> WithConfig for PolyphaseFilterBankArray<K, N> {
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        Self::from_parts(config)
+    }
+}
+
+impl<C> ConfigRef for PolyphaseFilterBank<C> {
+    fn config_ref(&self) -> &Self::Config {
+        &self.config
+    }
+}
+
+impl<C> ConfigClone for PolyphaseFilterBank<C>
+where
+    Config<C>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.config.clone()
+    }
+}
+
+impl<C> HasGuts for PolyphaseFilterBank<C> {
+    type Guts = Config<C>;
+}
+
+impl<C> FromGuts for PolyphaseFilterBank<C> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        Self { config: guts }
+    }
+}
+
+impl<C> IntoGuts for PolyphaseFilterBank<C> {
+    fn into_guts(self) -> Self::Guts {
+        self.config
+    }
+}
+
+impl<C> Reset for PolyphaseFilterBank<C> {
+    fn reset(self) -> Self {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, PolyphaseFilterBank, PolyphaseFilterBankArray, PolyphaseFilterBankRefMut};
+    use crate::traits::WithConfig;
+
+    #[test]
+    fn from_parts_accepts_phase_major_coefficients() {
+        let bank = PolyphaseFilterBankArray::<i32, 6>::from_parts(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+
+        assert_eq!(bank.num_phases(), 3);
+        assert_eq!(bank.taps_per_phase(), 2);
+        assert_eq!(bank.total_taps(), 6);
+        assert_eq!(bank.phase_coefficients(0), &[1, 4]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 5]);
+        assert_eq!(bank.phase_coefficients(2), &[3, 6]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn from_prototype_taps_reorders_and_pads() {
+        use super::PolyphaseFilterBankVec;
+
+        let bank = PolyphaseFilterBankVec::<i32>::from_prototype_taps(3, &[1, 2, 3, 4, 5]);
+
+        assert_eq!(bank.num_phases(), 3);
+        assert_eq!(bank.taps_per_phase(), 2);
+        assert_eq!(bank.config.coefficients.as_slice(), &[1, 4, 2, 5, 3, 0]);
+        assert_eq!(bank.phase_coefficients(0), &[1, 4]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 5]);
+        assert_eq!(bank.phase_coefficients(2), &[3, 0]);
+    }
+
+    #[test]
+    fn with_config_accepts_phase_major_coefficients() {
+        let bank = PolyphaseFilterBank::<[i32; 4]>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        assert_eq!(bank.phase_coefficients(0), &[1, 3]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 4]);
+    }
+
+    #[test]
+    fn execute_uses_normal_convolution_order() {
+        let bank = PolyphaseFilterBankArray::<i32, 6>::from_parts(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+
+        assert_eq!(bank.execute(0, [10, 40].iter()), 80);
+        assert_eq!(bank.execute(1, [20, 50].iter()), 200);
+        assert_eq!(bank.execute(2, [30, 60].iter()), 360);
+    }
+
+    #[test]
+    #[should_panic(expected = "phase index out of range")]
+    fn execute_phase_out_of_range_panics() {
+        let bank = PolyphaseFilterBankArray::<i32, 4>::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let _ = bank.execute(2, [10, 20].iter());
+    }
+
+    #[test]
+    #[should_panic(expected = "taps count must equal taps_per_phase")]
+    fn execute_taps_count_mismatch_panics() {
+        let bank = PolyphaseFilterBankArray::<i32, 4>::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let _ = bank.execute(0, [10].iter());
+    }
+
+    #[test]
+    fn ref_mut_uses_caller_owned_phase_major_coefficients() {
+        let mut coefficients = [1, 3, 2, 4];
+        let bank: PolyphaseFilterBankRefMut<'_, i32> = PolyphaseFilterBank::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: &mut coefficients[..],
+        });
+
+        assert_eq!(bank.phase_coefficients(0), &[1, 3]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 4]);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,13 @@ extern crate std;
 #[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
 
+#[cfg(feature = "complex")]
+pub mod complex {
+    //! Complex number types for DSP pipelines.
+
+    pub use num_complex::{Complex, Complex32, Complex64};
+}
+
 pub mod math;
 
 pub mod storage;


### PR DESCRIPTION
Introduce the first low-level pieces needed for polyphase multirate primitives.

Add `PolyphaseFilterBank` (also known as PFB), a low-level phase-major FIR coefficient bank with array, `Vec`, and borrowed-slice storage aliases.

It stores normal FIR coefficients by phase:

```text
phase p: h[p], h[p + P], h[p + 2P], ...
```

where `P = num_phases`.

The bank exposes:

- phase metadata (number of phases, taps per phase, total taps)
- per-phase coefficient slices
- selected-phase execution against caller-provided sample history

```rust
bank.execute(phase, taps.iter())
```

`execute(phase, taps)` expects sample history in oldest-to-newest order and pairs `h[p]` with the newest sample.

`PolyphaseFilterBank` does not own a delay line, advance time, or define interpolation/decimation/resampling semantics. It also does not reverse or reinterpret coefficients. That keeps the config/store side close to `fir::Convolve`: coefficients are normal FIR coefficients, and the user can prepare the prototype taps they want before packing, e.g. convolution taps, correlation taps, or matched-filter taps.
For matched filtering, build:
```text
h_mf = reverse(conj(template))
```

and then pack those coefficients:
```rust
PolyphaseFilterBankVec::from_prototype_taps(num_phases, &h_mf)
```

Padding then happens at the tail of the FIR coefficient sequence, which is the correct side.

Add an `alloc`-only `PolyphaseFilterBankVec::from_prototype_taps` constructor that accepts normal FIR taps, pads the tail as needed, and packs them into phase-major layout.

This provides the coefficient-bank foundation for higher-level polyphase FIR, interpolation, decimation, rational resampling, and fractional-delay layers.

Part of #167.