### PR TITLE
Polyphase multirate primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,14 @@ Please make sure to add your changes to the appropriate categories:
 - Added `*Vec` (heap-allocated, requires `alloc` feature) type aliases for all applicable storage-generic filters, sinks, and window functions
 - Added `*RefMut` (borrowed) type aliases for all applicable storage-generic filters, sinks, and window functions
 - Added `from_parts()` constructors to all storage-generic types for constructing with pre-initialized storage
+- Added `MultirateFilter` trait for streaming rate-changing filters with independent input and output progress
+- Added `PolyphaseFilterBank` coefficient container with array, vec, and borrowed storage aliases
+- Added `PolyphaseFir` polyphase FIR executor with shared delay line
+- Added `PolyphaseInterpolator` streaming multirate interpolator
+- Added `PolyphaseDecimator` streaming multirate decimator
+- Added `RationalResampler` streaming multirate resampler with configurable interpolation/decimation ratio
+- Added "complex" feature (opt-in `dep:num-complex`) for `Complex<T>` IQ sample support
+- Made `Convolve` generic over coefficient type `K` to support complex input with real taps (fixes #166)
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "signalo"
 description = "A DSP toolbox with focus on embedded environments."
 categories = ["no-std", "embedded", "multimedia", "science", "algorithms"]
-keywords = ["dsp", "digital-signal", "signal-processing", "filters", "pipeline"]
+keywords = ["dsp", "digital-signal-processing", "sdr", "software-defined-radio"]
 readme = "README.md"
 license = "MPL-2.0"
 repository = "https://github.com/signalo/signalo"
@@ -15,6 +15,7 @@ circular-buffer = { version = "2.0.0", default-features = false }
 dimensioned = { version = "0.8", optional = true, default-features = false }
 guts = { version = "0.2.0", default-features = false }
 libm = { version = "0.2.16", optional = true, default-features = false }
+num-complex = { version = "0.4", optional = true, default-features = false }
 num-traits = { version = "0.2", default-features = false }
 replace_with = { version = "0.1.5", default-features = false }
 
@@ -25,12 +26,14 @@ droptest = "0.2.1"
 [features]
 default = ["std"]
 alloc = ["circular-buffer/alloc"]
-libm = ["dep:libm", "num-traits/libm"]
+complex = ["dep:num-complex"]
+libm = ["dep:libm", "num-complex?/libm", "num-traits/libm"]
 std = [
     "alloc",
     "guts/std",
     "replace_with/std",
     "circular-buffer/std",
+    "num-complex?/std",
     "num-traits/std",
     "dimensioned?/std",
 ]

--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ based on zero-cost, zero-allocation abstractions, which can be **assembled via c
 
 ## About
 
-Signalo basically consists of four basic traits and implementations thereof:
+Signalo basically consists of five basic traits and implementations thereof:
 
 - `Source<T>`: `() -> T`
 - `Filter<T>`: `T -> U`
+- `MultirateFilter<T>`: `(&[T], &mut [U]) -> (usize, usize)`
 - `Sink<T>`: `T -> ()`
 - `Finalize`: `() -> U`
 
@@ -24,6 +25,9 @@ Roughly signalo's traits are equivalent in semantics to the following stdlib API
 - `Filter<…>` ≈ `core::iter::Map<…>`
 - `Sink<…> + Finalize` ≈ `Iterator::fold(…)`
 - `Filter<…> + Finalize` ≈ `core::iter::Scan<…>`
+
+`MultirateFilter<T>` has no direct stdlib iterator equivalent because input
+and output progress can differ on each call.
 
 Types implementing `Finalize` usually also implement either `Filter<T>` or `Sink<T>`.
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -4,8 +4,9 @@
 
 //! Composable signal-processing filters.
 //!
-//! All filters implement the [`Filter<T>`](crate::traits::Filter) trait
-//! and can be chained together in pipelines.
+//! Sample-by-sample filters implement the [`Filter<T>`](crate::traits::Filter)
+//! trait and can be chained together in pipelines. Rate-changing filters use
+//! [`MultirateFilter`](crate::traits::MultirateFilter) instead.
 
 pub use crate::traits;
 

--- a/src/filters/fir.rs
+++ b/src/filters/fir.rs
@@ -45,5 +45,6 @@ pub mod convolve;
 pub mod differentiate;
 pub mod mean;
 pub mod mean_variance;
+pub mod polyphase;
 pub mod savitzky_golay;
 pub mod window;

--- a/src/filters/fir/convolve.rs
+++ b/src/filters/fir/convolve.rs
@@ -5,9 +5,10 @@
 //! Convolution filters.
 
 use core::marker::PhantomData;
+use core::ops::{Add, Mul};
 
 use circular_buffer::{CircularBuffer, FixedCircularBuffer};
-use num_traits::Num;
+use num_traits::{Num, Zero};
 
 use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
 use crate::traits::{
@@ -29,7 +30,7 @@ pub mod windowed_sinc;
 
 /// The convolution filter's configuration.
 ///
-/// Holds the coefficient storage `C`, which must implement [`AsSlice<T>`]
+/// Holds the coefficient storage `C`, which must implement [`AsSlice<K>`]
 /// on relevant impls. Use [`ConvolveArray`] for stack-allocated coefficients
 /// or [`ConvolveVec`] for heap-allocated ones.
 #[derive(Clone, Debug)]
@@ -48,7 +49,8 @@ pub struct State<R> {
     pub taps: R,
 }
 
-/// A convolution filter generic over coefficient storage `C` and tap storage `R`.
+/// A convolution filter generic over sample type `T`, coefficient storage `C`,
+/// tap storage `R`, and coefficient type `K`.
 ///
 /// # Coefficient ordering
 ///
@@ -77,10 +79,10 @@ pub struct State<R> {
 /// - [`ConvolveArray<T, N>`] — stack-allocated, `no_std`-friendly.
 /// - [`ConvolveVec<T>`] — heap-allocated, requires the `alloc` feature.
 #[derive(Clone, Debug)]
-pub struct Convolve<T, C, R> {
+pub struct Convolve<T, C, R, K = T> {
     config: Config<C>,
     state: State<R>,
-    _pd: PhantomData<T>,
+    _pd: PhantomData<(T, K)>,
 }
 
 /// A convolution filter backed by a const-generic array of coefficients and a
@@ -88,7 +90,8 @@ pub struct Convolve<T, C, R> {
 ///
 /// This alias is the `no_std`-friendly, zero-allocation form. Both the
 /// coefficient array and the tap ring-buffer live entirely on the stack.
-pub type ConvolveArray<T, const N: usize> = Convolve<T, [T; N], FixedCircularBuffer<T, N>>;
+pub type ConvolveArray<T, const N: usize, K = T> =
+    Convolve<T, [K; N], FixedCircularBuffer<T, N>, K>;
 
 /// A convolution filter backed by heap-allocated [`Vec`](alloc::vec::Vec) coefficients
 /// and a [`HeapCircularBuffer`] tap buffer.
@@ -97,20 +100,20 @@ pub type ConvolveArray<T, const N: usize> = Convolve<T, [T; N], FixedCircularBuf
 /// this variant, since the tap buffer cannot be `Default`-constructed without
 /// knowing the desired capacity at compile time.
 #[cfg(feature = "alloc")]
-pub type ConvolveVec<T> = Convolve<T, alloc::vec::Vec<T>, HeapCircularBuffer<T>>;
+pub type ConvolveVec<T, K = T> = Convolve<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
 
 /// A convolution filter that borrows a [`CircularBuffer`] tap buffer.
 ///
 /// This alias allows sharing a caller-owned ring buffer without taking
 /// ownership of it. The coefficient storage `C` remains generic — use
-/// any type implementing [`AsSlice<T>`](crate::storage::AsSlice).
+/// any type implementing [`AsSlice<K>`](crate::storage::AsSlice).
 /// Construct via [`Convolve::from_parts`], passing
 /// a `&mut CircularBuffer<T>` for the tap buffer.
-pub type ConvolveRefMut<'a, T, C> = Convolve<T, C, &'a mut CircularBuffer<T>>;
+pub type ConvolveRefMut<'a, T, C, K = T> = Convolve<T, C, &'a mut CircularBuffer<T>, K>;
 
-impl<T, C, R> Convolve<T, C, R>
+impl<T, C, R, K> Convolve<T, C, R, K>
 where
-    C: AsSlice<T>,
+    C: AsSlice<K>,
     R: RingBuffer<T>,
 {
     /// Creates a [`Convolve`] filter from an already-constructed `config` and
@@ -187,15 +190,15 @@ where
     }
 }
 
-impl<T, C, R> ConfigTrait for Convolve<T, C, R> {
+impl<T, C, R, K> ConfigTrait for Convolve<T, C, R, K> {
     type Config = Config<C>;
 }
 
-impl<T, C, R> StateTrait for Convolve<T, C, R> {
+impl<T, C, R, K> StateTrait for Convolve<T, C, R, K> {
     type State = State<R>;
 }
 
-impl<T, const N: usize> WithConfig for ConvolveArray<T, N>
+impl<T, const N: usize, K> WithConfig for ConvolveArray<T, N, K>
 where
     T: Num,
 {
@@ -225,13 +228,13 @@ where
     }
 }
 
-impl<T, C, R> ConfigRef for Convolve<T, C, R> {
+impl<T, C, R, K> ConfigRef for Convolve<T, C, R, K> {
     fn config_ref(&self) -> &Self::Config {
         &self.config
     }
 }
 
-impl<T, C, R> ConfigClone for Convolve<T, C, R>
+impl<T, C, R, K> ConfigClone for Convolve<T, C, R, K>
 where
     Config<C>: Clone,
 {
@@ -240,17 +243,17 @@ where
     }
 }
 
-impl<T, C, R> StateMut for Convolve<T, C, R> {
+impl<T, C, R, K> StateMut for Convolve<T, C, R, K> {
     fn state_mut(&mut self) -> &mut Self::State {
         &mut self.state
     }
 }
 
-impl<T, C, R> HasGuts for Convolve<T, C, R> {
+impl<T, C, R, K> HasGuts for Convolve<T, C, R, K> {
     type Guts = (Config<C>, State<R>);
 }
 
-impl<T, C, R> FromGuts for Convolve<T, C, R> {
+impl<T, C, R, K> FromGuts for Convolve<T, C, R, K> {
     fn from_guts(guts: Self::Guts) -> Self {
         let (config, state) = guts;
         Self {
@@ -261,13 +264,13 @@ impl<T, C, R> FromGuts for Convolve<T, C, R> {
     }
 }
 
-impl<T, C, R> IntoGuts for Convolve<T, C, R> {
+impl<T, C, R, K> IntoGuts for Convolve<T, C, R, K> {
     fn into_guts(self) -> Self::Guts {
         (self.config, self.state)
     }
 }
 
-impl<T, const N: usize> Reset for ConvolveArray<T, N>
+impl<T, const N: usize, K> Reset for ConvolveArray<T, N, K>
 where
     T: Num,
 {
@@ -277,12 +280,13 @@ where
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize> ResetMut for ConvolveArray<T, N> where Self: Reset {}
+impl<T, const N: usize, K> ResetMut for ConvolveArray<T, N, K> where Self: Reset {}
 
-impl<T, C, R> Filter<T> for Convolve<T, C, R>
+impl<T, C, R, K> Filter<T> for Convolve<T, C, R, K>
 where
-    T: Clone + Num,
-    C: AsSlice<T>,
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: AsSlice<K>,
     R: RingBuffer<T>,
 {
     type Output = T;
@@ -298,7 +302,7 @@ where
         state_iter
             .zip(coeff_iter)
             .fold(T::zero(), |sum, (state, coeff)| {
-                sum + (state.clone() * coeff.clone())
+                sum + ((*state).clone() * (*coeff).clone())
             })
     }
 }

--- a/src/filters/fir/convolve/tests.rs
+++ b/src/filters/fir/convolve/tests.rs
@@ -106,6 +106,30 @@ fn integer_convolution() {
     assert_eq!(filter2.filter(2), 3);
 }
 
+#[cfg(feature = "complex")]
+#[test]
+fn real_taps_complex_samples_match_independent_real_filters() {
+    use crate::complex::Complex32;
+
+    let coefficients = [0.5_f32, -0.25, 0.125, 0.0625];
+    let real_input = [1.0_f32, -2.0, 3.0, 5.0, -8.0, 13.0, -21.0];
+    let imag_input = [34.0_f32, -55.0, 89.0, -144.0, 233.0, -377.0, 610.0];
+
+    let mut real_filter = ConvolveArray::<f32, 4>::with_config(Config { coefficients });
+    let mut imag_filter = ConvolveArray::<f32, 4>::with_config(Config { coefficients });
+    let mut complex_filter =
+        ConvolveArray::<Complex32, 4, f32>::with_config(Config { coefficients });
+
+    for (&real, &imag) in real_input.iter().zip(&imag_input) {
+        let real_output = real_filter.filter(real);
+        let imag_output = imag_filter.filter(imag);
+        let complex_output = complex_filter.filter(Complex32::new(real, imag));
+
+        assert_abs_diff_eq!(complex_output.re, real_output, epsilon = 1e-6);
+        assert_abs_diff_eq!(complex_output.im, imag_output, epsilon = 1e-6);
+    }
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[test]
 #[should_panic(expected = "denominator magnitude")]

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -1,0 +1,7 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR filter banks, executors, and multirate filters.
+
+pub mod filter_bank;

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -7,3 +7,4 @@
 pub mod filter_bank;
 pub mod fir;
 pub mod interpolator;
+pub mod decimator;

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -3,8 +3,15 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //! Polyphase FIR filter banks, executors, and multirate filters.
+//!
+//! [`filter_bank`] contains the coefficient storage and selected-phase execution
+//! primitive. [`fir`] adds sample history. The [`interpolator`], [`decimator`], and
+//! [`rational_resampler`] modules build streaming
+//! [`MultirateFilter`](crate::traits::MultirateFilter) adapters on top of those
+//! primitives.
 
+pub mod decimator;
 pub mod filter_bank;
 pub mod fir;
 pub mod interpolator;
-pub mod decimator;
+pub mod rational_resampler;

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -4,4 +4,9 @@
 
 //! Polyphase FIR filter banks, executors, and multirate filters.
 
+<<<<<<< HEAD
 pub mod filter_bank;
+=======
+pub mod filter_bank;
+pub mod fir;
+>>>>>>> 7c6659b (Add polyphase FIR executor)

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -4,9 +4,6 @@
 
 //! Polyphase FIR filter banks, executors, and multirate filters.
 
-<<<<<<< HEAD
-pub mod filter_bank;
-=======
 pub mod filter_bank;
 pub mod fir;
->>>>>>> 7c6659b (Add polyphase FIR executor)
+pub mod interpolator;

--- a/src/filters/fir/polyphase/decimator.rs
+++ b/src/filters/fir/polyphase/decimator.rs
@@ -1,0 +1,585 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR decimation.
+
+use core::marker::PhantomData;
+use core::ops::{Add, Mul};
+
+use circular_buffer::FixedCircularBuffer;
+use num_traits::{Num, Zero};
+
+use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, MultirateFilter, Reset, WithConfig,
+};
+
+use super::filter_bank::{Config, PolyphaseFilterBank};
+
+#[cfg(feature = "alloc")]
+use circular_buffer::HeapCircularBuffer;
+
+#[cfg(feature = "alloc")]
+use super::filter_bank::PolyphaseFilterBankVec;
+
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+
+/// The polyphase decimator's state.
+#[derive(Clone, Debug)]
+pub struct State<R> {
+    /// Buffered input samples, one delay-line buffer per phase.
+    pub taps: R,
+    /// The phase branch that will receive the next input sample.
+    pub phase: usize,
+}
+
+/// A stateful M-to-1 polyphase decimator.
+///
+/// This type owns one delay-line buffer per phase branch. Each consumed input
+/// sample updates the selected phase buffer. The input commutator counts down
+/// from the last phase to phase zero. Whenever phase zero is updated, the
+/// decimator evaluates all phase branches and produces one output sample.
+///
+/// The first output is therefore produced only after `num_phases` input samples
+/// have been consumed. This matches the usual M-to-1 decimator convention: a
+/// complete input block advances all phase branches, then one decimated sample
+/// is emitted.
+///
+/// Coefficients follow the phase-major ordering described by
+/// [`PolyphaseFilterBank`].
+///
+/// # Gain
+///
+/// This type does not apply gain correction after summing the phase outputs.
+/// Use a prototype filter with unity passband gain when unity-amplitude output
+/// is required.
+///
+/// # Streaming
+///
+/// The [`MultirateFilter::process`] implementation supports streaming operation
+/// with arbitrary input and output slice sizes. If the output slice is full
+/// before the phase-zero input can be consumed, that input remains unconsumed and
+/// should be passed again on a later [`process`](MultirateFilter::process) call.
+///
+/// When the output slice is empty, the decimator can still consume input samples
+/// for non-zero phase branches. Only the sample that would update phase zero and
+/// produce an output is deferred; pass it again as the first input sample on the
+/// next call with output space available.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`PolyphaseDecimatorArray<T, N, H, P, K>`] for stack-allocated
+///   coefficients and per-phase delay-line storage.
+#[cfg_attr(
+    feature = "alloc",
+    doc = "- [`PolyphaseDecimatorVec<T, K>`] for heap-allocated coefficients and per-phase delay-line storage."
+)]
+#[cfg_attr(
+    not(feature = "alloc"),
+    doc = "- `PolyphaseDecimatorVec<T, K>` for heap-allocated coefficients and per-phase delay-line storage."
+)]
+#[derive(Clone, Debug)]
+pub struct PolyphaseDecimator<T, C, R, B, K = T> {
+    bank: PolyphaseFilterBank<C>,
+    state: State<R>,
+    _pd: PhantomData<(T, B, K)>,
+}
+
+/// A polyphase decimator backed by fixed coefficient and per-phase delay-line
+/// storage.
+///
+/// `N` is the total coefficient count. `H` is the number of coefficients in
+/// each phase branch. `P` is the decimation factor and must match the
+/// configuration's `num_phases`.
+pub type PolyphaseDecimatorArray<T, const N: usize, const H: usize, const P: usize, K = T> =
+    PolyphaseDecimator<T, [K; N], [FixedCircularBuffer<T, H>; P], FixedCircularBuffer<T, H>, K>;
+
+/// A polyphase decimator backed by heap-allocated storage.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub type PolyphaseDecimatorVec<T, K = T> = PolyphaseDecimator<
+    T,
+    alloc::vec::Vec<K>,
+    alloc::vec::Vec<HeapCircularBuffer<T>>,
+    HeapCircularBuffer<T>,
+    K,
+>;
+
+impl<T, C, R, B, K> PolyphaseDecimator<T, C, R, B, K>
+where
+    C: AsSlice<K>,
+    R: AsSlice<B>,
+    B: RingBuffer<T>,
+{
+    /// Creates a [`PolyphaseDecimator`] from an already-constructed `config` and
+    /// buffers.
+    ///
+    /// Use this constructor when the per-phase delay-line storage is
+    /// caller-owned or must be constructed with runtime capacities.
+    ///
+    /// The delay-line buffers are taken as-is with their current contents. Each
+    /// buffer must contain `taps_per_phase` samples before its phase branch is
+    /// evaluated.
+    ///
+    /// # Expected storage state
+    ///
+    /// For zero-padded cold-start behavior, prefill every buffer with
+    /// `taps_per_phase` zeros before passing them here.
+    ///
+    /// The initial phase is set to the last branch so the first output is
+    /// produced after one full decimation block.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of delay-line buffers does not equal
+    /// `config.num_phases`, or if any buffer capacity does not equal
+    /// `config.taps_per_phase`.
+    pub fn from_parts(config: Config<C>, taps: R) -> Self {
+        let bank = PolyphaseFilterBank::from_parts(config);
+        assert_eq!(
+            taps.as_slice().len(),
+            bank.num_phases(),
+            "PolyphaseDecimator: taps count must equal num_phases"
+        );
+        for tap_buffer in taps.as_slice() {
+            assert_eq!(
+                tap_buffer.capacity(),
+                bank.taps_per_phase(),
+                "PolyphaseDecimator: taps capacity must equal taps_per_phase"
+            );
+        }
+        Self {
+            state: State {
+                taps,
+                phase: bank.num_phases() - 1,
+            },
+            bank,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T, C, R, B, K> PolyphaseDecimator<T, C, R, B, K> {
+    /// Returns the number of polyphase branches and decimation factor.
+    #[must_use]
+    pub fn num_phases(&self) -> usize {
+        self.bank.num_phases()
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.bank.taps_per_phase()
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.bank.total_taps()
+    }
+}
+
+impl<T, C, R, B, K> ConfigTrait for PolyphaseDecimator<T, C, R, B, K> {
+    type Config = Config<C>;
+}
+
+impl<T, const N: usize, const H: usize, const P: usize, K> WithConfig
+    for PolyphaseDecimatorArray<T, N, H, P, K>
+where
+    T: Num,
+{
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        let taps = core::array::from_fn(|_| zero_filled_fixed_ring::<T, H>());
+        Self::from_parts(config, taps)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, K> PolyphaseDecimatorVec<T, K>
+where
+    T: Clone + Zero,
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed polyphase decimator from dense prototype
+    /// coefficients.
+    ///
+    /// This convenience constructor allocates coefficient and per-phase
+    /// delay-line storage. `prototype` is passed to
+    /// [`PolyphaseFilterBankVec::from_prototype_taps`] for ordering and padding
+    /// behavior. The decimator delay-line buffers are zero-filled.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `decimation` is zero, `prototype` is empty, or the padded
+    /// coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(decimation: usize, prototype: &[K]) -> Self {
+        let bank = PolyphaseFilterBankVec::from_prototype_taps(decimation, prototype);
+        let mut taps = alloc::vec::Vec::with_capacity(bank.num_phases());
+        for _ in 0..bank.num_phases() {
+            let mut tap_buffer = HeapCircularBuffer::with_capacity(bank.taps_per_phase());
+            for _ in 0..bank.taps_per_phase() {
+                let _ = tap_buffer.push_back(T::zero());
+            }
+            taps.push(tap_buffer);
+        }
+        Self::from_parts(bank.into_guts(), taps)
+    }
+}
+
+impl<T, C, R, B, K> ConfigRef for PolyphaseDecimator<T, C, R, B, K> {
+    fn config_ref(&self) -> &Self::Config {
+        self.bank.config_ref()
+    }
+}
+
+impl<T, C, R, B, K> ConfigClone for PolyphaseDecimator<T, C, R, B, K>
+where
+    Config<C>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.bank.config()
+    }
+}
+
+impl<T, C, R, B, K> HasGuts for PolyphaseDecimator<T, C, R, B, K> {
+    type Guts = (Config<C>, State<R>);
+}
+
+impl<T, C, R, B, K> FromGuts for PolyphaseDecimator<T, C, R, B, K> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        let (config, state) = guts;
+        Self {
+            bank: PolyphaseFilterBank::from_guts(config),
+            state,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T, C, R, B, K> IntoGuts for PolyphaseDecimator<T, C, R, B, K> {
+    fn into_guts(self) -> Self::Guts {
+        (self.bank.into_guts(), self.state)
+    }
+}
+
+impl<T, const N: usize, const H: usize, const P: usize, K> Reset
+    for PolyphaseDecimatorArray<T, N, H, P, K>
+where
+    T: Num,
+{
+    fn reset(self) -> Self {
+        Self::with_config(self.bank.into_guts())
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T, const N: usize, const H: usize, const P: usize, K> ResetMut
+    for PolyphaseDecimatorArray<T, N, H, P, K>
+where
+    Self: Reset,
+{
+}
+
+impl<T, C, R, B, K> MultirateFilter<T> for PolyphaseDecimator<T, C, R, B, K>
+where
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: AsSlice<K>,
+    R: AsSlice<B>,
+    B: RingBuffer<T>,
+{
+    type Output = T;
+
+    fn process(&mut self, input: &[T], output: &mut [Self::Output]) -> (usize, usize) {
+        let mut input_consumed = 0;
+        let mut output_produced = 0;
+
+        while input_consumed < input.len() {
+            let phase = self.state.phase;
+            if phase == 0 && output_produced == output.len() {
+                break;
+            }
+
+            self.state.taps.as_mut_slice()[phase].push_back(input[input_consumed].clone());
+            input_consumed += 1;
+
+            let output_ready = phase == 0;
+            self.state.phase = if phase == 0 {
+                self.num_phases() - 1
+            } else {
+                phase - 1
+            };
+
+            if output_ready {
+                let decimated = (0..self.num_phases())
+                    .map(|phase| {
+                        self.bank
+                            .execute(phase, self.state.taps.as_slice()[phase].iter())
+                    })
+                    .fold(T::zero(), |sum, partial| sum + partial);
+                output[output_produced] = decimated;
+                output_produced += 1;
+            }
+        }
+
+        (input_consumed, output_produced)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PolyphaseDecimator, PolyphaseDecimatorArray, State};
+    use crate::filters::fir::convolve::{Config as ConvolveConfig, ConvolveArray};
+    use crate::filters::fir::polyphase::filter_bank::Config;
+    use crate::traits::{
+        guts::{FromGuts, IntoGuts},
+        Filter, MultirateFilter, Reset, WithConfig,
+    };
+
+    #[test]
+    fn process_decimates_all_outputs() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let input = [10, 20, 30, 40, 50, 60];
+        let mut output = [0; 2];
+
+        assert_eq!(decimator.process(&input, &mut output), (6, 2));
+        assert_eq!(output, [100, 560]);
+    }
+
+    #[test]
+    fn process_waits_for_full_decimation_block_before_output() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let mut output = [999];
+
+        assert_eq!(decimator.process(&[10, 20], &mut output), (2, 0));
+        assert_eq!(output, [999]);
+
+        assert_eq!(decimator.process(&[30], &mut output), (1, 1));
+        assert_eq!(output, [100]);
+    }
+
+    #[test]
+    fn process_matches_convolve_then_downsample() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let mut convolve = ConvolveArray::<i32, 6>::with_config(ConvolveConfig {
+            coefficients: [1, 2, 3, 4, 5, 6],
+        });
+        let input = [10, 20, 30, 40, 50, 60, 70, 80, 90];
+        let mut expected = [0; 3];
+        let mut expected_len = 0;
+
+        for (index, sample) in input.iter().copied().enumerate() {
+            let output = convolve.filter(sample);
+            if index % 3 == 2 {
+                expected[expected_len] = output;
+                expected_len += 1;
+            }
+        }
+
+        let mut output = [0; 3];
+        assert_eq!(decimator.process(&input, &mut output), (9, 3));
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn process_leaves_phase_zero_input_unconsumed_when_output_is_full() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let input = [10, 20, 30, 40, 50, 60];
+        let mut first_output = [0; 1];
+        let mut second_output = [0; 1];
+
+        assert_eq!(decimator.process(&input, &mut first_output), (5, 1));
+        assert_eq!(first_output, [100]);
+
+        assert_eq!(decimator.process(&input[5..], &mut second_output), (1, 1));
+        assert_eq!(second_output, [560]);
+    }
+
+    #[test]
+    fn empty_output_can_still_consume_until_output_boundary() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let mut output = [0; 1];
+
+        assert_eq!(decimator.process(&[10, 20, 30, 40], &mut []), (2, 0));
+        assert_eq!(decimator.process(&[30], &mut output), (1, 1));
+        assert_eq!(output, [100]);
+    }
+
+    #[test]
+    fn reset_clears_taps_and_phase() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let mut output = [0; 1];
+
+        assert_eq!(decimator.process(&[10, 20], &mut []), (2, 0));
+        let mut decimator = decimator.reset();
+
+        assert_eq!(decimator.process(&[20, 30, 40], &mut output), (3, 1));
+        assert_eq!(output, [160]);
+    }
+
+    #[test]
+    #[should_panic(expected = "taps capacity must equal taps_per_phase")]
+    fn from_parts_capacity_mismatch_panics() {
+        let config = Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        };
+        let taps = [
+            circular_buffer::FixedCircularBuffer::<i32, 3>::new(),
+            circular_buffer::FixedCircularBuffer::<i32, 3>::new(),
+        ];
+        let _ = PolyphaseDecimator::from_parts(config, taps);
+    }
+
+    #[test]
+    fn guts_round_trip_preserves_phase() {
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        assert_eq!(decimator.process(&[10, 20], &mut []), (2, 0));
+
+        let guts = decimator.into_guts();
+        let mut decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::from_guts(guts);
+        let mut output = [0; 1];
+
+        assert_eq!(decimator.process(&[30], &mut output), (1, 1));
+        assert_eq!(output, [100]);
+    }
+
+    #[test]
+    fn from_guts_accepts_existing_state() {
+        let mut phase0 = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = phase0.push_back(10);
+        let _ = phase0.push_back(40);
+        let mut phase1 = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = phase1.push_back(0);
+        let _ = phase1.push_back(30);
+        let mut phase2 = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = phase2.push_back(0);
+        let _ = phase2.push_back(20);
+
+        let decimator = PolyphaseDecimatorArray::<i32, 6, 2, 3>::from_guts((
+            Config {
+                num_phases: 3,
+                taps_per_phase: 2,
+                coefficients: [1, 4, 2, 5, 3, 6],
+            },
+            State {
+                taps: [phase0, phase1, phase2],
+                phase: 2,
+            },
+        ));
+
+        assert_eq!(decimator.state.phase, 2);
+        assert!(decimator.state.taps[0].iter().copied().eq([10, 40]));
+        assert!(decimator.state.taps[1].iter().copied().eq([0, 30]));
+        assert!(decimator.state.taps[2].iter().copied().eq([0, 20]));
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec_from_prototype_taps_decimates() {
+        let mut decimator =
+            super::PolyphaseDecimatorVec::<i32>::from_prototype_taps(3, &[1, 2, 3, 4, 5, 6]);
+        let input = [10, 20, 30, 40, 50, 60];
+        let mut output = [0; 2];
+
+        assert_eq!(decimator.process(&input, &mut output), (6, 2));
+        assert_eq!(output, [100, 560]);
+    }
+
+    #[cfg(feature = "complex")]
+    #[test]
+    fn real_taps_complex_samples_match_independent_real_decimators() {
+        use approx::assert_abs_diff_eq;
+
+        use crate::complex::Complex32;
+
+        let coefficients = [0.5_f32, 0.125, -0.25, 0.0625];
+        let real_input = [1.0_f32, -2.0, 3.0, 5.0, -8.0];
+        let imag_input = [13.0_f32, -21.0, 34.0, -55.0, 89.0];
+        let complex_input = [
+            Complex32::new(real_input[0], imag_input[0]),
+            Complex32::new(real_input[1], imag_input[1]),
+            Complex32::new(real_input[2], imag_input[2]),
+            Complex32::new(real_input[3], imag_input[3]),
+            Complex32::new(real_input[4], imag_input[4]),
+        ];
+        let mut real_decimator = PolyphaseDecimatorArray::<f32, 4, 2, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut imag_decimator = PolyphaseDecimatorArray::<f32, 4, 2, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut complex_decimator =
+            PolyphaseDecimatorArray::<Complex32, 4, 2, 2, f32>::with_config(Config {
+                num_phases: 2,
+                taps_per_phase: 2,
+                coefficients,
+            });
+        let mut real_output = [0.0; 2];
+        let mut imag_output = [0.0; 2];
+        let mut complex_output = [Complex32::new(0.0, 0.0); 2];
+
+        assert_eq!(
+            real_decimator.process(&real_input, &mut real_output),
+            (5, 2)
+        );
+        assert_eq!(
+            imag_decimator.process(&imag_input, &mut imag_output),
+            (5, 2)
+        );
+        assert_eq!(
+            complex_decimator.process(&complex_input, &mut complex_output),
+            (5, 2)
+        );
+
+        for ((complex, real), imag) in complex_output
+            .iter()
+            .zip(real_output.iter())
+            .zip(imag_output.iter())
+        {
+            assert_abs_diff_eq!(complex.re, *real, epsilon = 1e-6);
+            assert_abs_diff_eq!(complex.im, *imag, epsilon = 1e-6);
+        }
+    }
+}

--- a/src/filters/fir/polyphase/filter_bank.rs
+++ b/src/filters/fir/polyphase/filter_bank.rs
@@ -1,0 +1,400 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR filter bank.
+
+use core::ops::{Add, Mul};
+
+use num_traits::Zero;
+
+use crate::storage::AsSlice;
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, Reset, WithConfig,
+};
+
+/// The polyphase filter bank's configuration.
+///
+/// Holds the phase-major coefficient storage `C`, which must implement
+/// [`AsSlice<K>`] on relevant impls. Use [`PolyphaseFilterBankArray`] for
+/// stack-allocated coefficients, `PolyphaseFilterBankVec` for heap-allocated
+/// coefficients, or [`PolyphaseFilterBankRefMut`] for caller-owned coefficient
+/// storage.
+#[derive(Clone, Debug)]
+pub struct Config<C> {
+    /// Number of polyphase branches.
+    pub num_phases: usize,
+    /// Number of coefficients in each phase branch.
+    pub taps_per_phase: usize,
+    /// Phase-major coefficients in normal FIR order within each phase.
+    ///
+    /// For phase `p`, the phase coefficient slice is:
+    ///
+    /// ```text
+    /// coefficients[p * taps_per_phase .. (p + 1) * taps_per_phase]
+    /// ```
+    pub coefficients: C,
+}
+
+/// A polyphase FIR filter bank.
+///
+/// This type stores phase coefficients and can evaluate a selected phase against
+/// caller-provided sample history. It does not own input history, advance time,
+/// or implement rate conversion by itself. Stateful users such as rational
+/// resamplers own delay lines and use [`Self::execute`] to evaluate selected
+/// phases.
+///
+/// # Coefficient ordering
+///
+/// Coefficients are stored phase-major in normal FIR order within each phase:
+///
+/// ```text
+/// phase p: h[p], h[p + P], h[p + 2P], ...
+/// ```
+///
+/// where `P = num_phases`. [`Self::execute`] accepts sample history in
+/// oldest-to-newest order. For the selected phase, the first phase coefficient
+/// is applied to the newest sample, matching normal FIR convolution coefficient
+/// semantics.
+///
+/// The bank does not reverse, conjugate, or otherwise reinterpret
+/// coefficients. For correlation or matched-filter behavior, prepare those FIR
+/// coefficients before phase packing. That means time-reversing the template
+/// coefficients; for complex templates, conjugate them as well.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`PolyphaseFilterBankArray<K, N>`] — stack-allocated, `no_std`-friendly.
+#[cfg_attr(
+    feature = "alloc",
+    doc = "- [`PolyphaseFilterBankVec<K>`] — heap-allocated, requires the `alloc` feature."
+)]
+#[cfg_attr(
+    not(feature = "alloc"),
+    doc = "- `PolyphaseFilterBankVec<K>` — heap-allocated, requires the `alloc` feature."
+)]
+/// - [`PolyphaseFilterBankRefMut<'_, K>`] — caller-owned coefficient storage.
+#[derive(Clone, Debug)]
+pub struct PolyphaseFilterBank<C> {
+    config: Config<C>,
+}
+
+/// A polyphase filter bank backed by a const-generic coefficient array.
+pub type PolyphaseFilterBankArray<K, const N: usize> = PolyphaseFilterBank<[K; N]>;
+
+/// A polyphase filter bank backed by heap-allocated coefficients.
+#[cfg(feature = "alloc")]
+pub type PolyphaseFilterBankVec<K> = PolyphaseFilterBank<alloc::vec::Vec<K>>;
+
+/// A polyphase filter bank that borrows caller-owned coefficient storage.
+pub type PolyphaseFilterBankRefMut<'a, K> = PolyphaseFilterBank<&'a mut [K]>;
+
+impl<C> PolyphaseFilterBank<C> {
+    /// Creates a [`PolyphaseFilterBank`] from phase-major coefficient storage.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_phases` or `taps_per_phase` is zero, or if
+    /// `coefficients.len() != num_phases * taps_per_phase`.
+    pub fn from_parts<K>(config: Config<C>) -> Self
+    where
+        C: AsSlice<K>,
+    {
+        assert!(
+            config.num_phases > 0,
+            "PolyphaseFilterBank: number of phases must be > 0"
+        );
+        assert!(
+            config.taps_per_phase > 0,
+            "PolyphaseFilterBank: taps per phase must be > 0"
+        );
+
+        let Some(expected_taps) = config.num_phases.checked_mul(config.taps_per_phase) else {
+            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
+        };
+
+        assert_eq!(
+            config.coefficients.as_slice().len(),
+            expected_taps,
+            "PolyphaseFilterBank: coefficient count must equal num_phases * taps_per_phase"
+        );
+
+        Self { config }
+    }
+
+    /// Returns the number of polyphase branches.
+    #[must_use]
+    pub fn num_phases(&self) -> usize {
+        self.config.num_phases
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.config.taps_per_phase
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.num_phases() * self.taps_per_phase()
+    }
+
+    /// Returns the phase-major coefficient slice for `phase`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phase >= self.num_phases()`.
+    #[must_use]
+    pub fn phase_coefficients<K>(&self, phase: usize) -> &[K]
+    where
+        C: AsSlice<K>,
+    {
+        assert!(
+            phase < self.num_phases(),
+            "PolyphaseFilterBank: phase index out of range"
+        );
+
+        let start = phase * self.taps_per_phase();
+        let end = start + self.taps_per_phase();
+        &self.config.coefficients.as_slice()[start..end]
+    }
+
+    /// Evaluates `phase` against caller-provided sample history.
+    ///
+    /// The `taps` iterator must yield samples in oldest-to-newest order. Phase
+    /// coefficients are paired so the first coefficient in the selected phase,
+    /// `h[phase]`, multiplies the newest sample.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phase >= self.num_phases()`, or if the number of samples
+    /// yielded by `taps` does not equal `self.taps_per_phase()`.
+    #[must_use]
+    pub fn execute<'a, T, K, I>(&self, phase: usize, taps: I) -> T
+    where
+        T: 'a + Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+        K: Clone,
+        C: AsSlice<K>,
+        I: IntoIterator<Item = &'a T>,
+    {
+        let coefficients = self.phase_coefficients(phase);
+        let mut taps = taps.into_iter();
+        let mut count = 0;
+        let output =
+            taps.by_ref()
+                .zip(coefficients.iter().rev())
+                .fold(T::zero(), |sum, (state, coeff)| {
+                    count += 1;
+                    sum + ((*state).clone() * (*coeff).clone())
+                });
+
+        assert!(
+            count == self.taps_per_phase() && taps.next().is_none(),
+            "PolyphaseFilterBank: taps count must equal taps_per_phase"
+        );
+
+        output
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<K> PolyphaseFilterBankVec<K>
+where
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed filter bank from dense prototype coefficients.
+    ///
+    /// This convenience constructor allocates coefficient storage. `prototype`
+    /// is provided in normal tap order, not phase-major order. It is zero-padded
+    /// at the tail as needed, then packed using the phase-major coefficient
+    /// ordering described on [`PolyphaseFilterBank`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_phases` is zero, `prototype` is empty, or the padded
+    /// coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(num_phases: usize, prototype: &[K]) -> Self {
+        assert!(
+            num_phases > 0,
+            "PolyphaseFilterBank: number of phases must be > 0"
+        );
+        assert!(
+            !prototype.is_empty(),
+            "PolyphaseFilterBank: tap count must be > 0"
+        );
+
+        let taps_per_phase = prototype.len().div_ceil(num_phases);
+        let Some(total_taps) = num_phases.checked_mul(taps_per_phase) else {
+            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
+        };
+
+        let mut coefficients = alloc::vec![K::zero(); total_taps];
+        for phase in 0..num_phases {
+            for tap in 0..taps_per_phase {
+                let src = tap * num_phases + phase;
+                if src < prototype.len() {
+                    let dst = phase * taps_per_phase + tap;
+                    coefficients[dst] = prototype[src].clone();
+                }
+            }
+        }
+
+        Self::from_parts(Config {
+            num_phases,
+            taps_per_phase,
+            coefficients,
+        })
+    }
+}
+
+impl<C> ConfigTrait for PolyphaseFilterBank<C> {
+    type Config = Config<C>;
+}
+
+impl<K, const N: usize> WithConfig for PolyphaseFilterBankArray<K, N> {
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        Self::from_parts(config)
+    }
+}
+
+impl<C> ConfigRef for PolyphaseFilterBank<C> {
+    fn config_ref(&self) -> &Self::Config {
+        &self.config
+    }
+}
+
+impl<C> ConfigClone for PolyphaseFilterBank<C>
+where
+    Config<C>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.config.clone()
+    }
+}
+
+impl<C> HasGuts for PolyphaseFilterBank<C> {
+    type Guts = Config<C>;
+}
+
+impl<C> FromGuts for PolyphaseFilterBank<C> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        Self { config: guts }
+    }
+}
+
+impl<C> IntoGuts for PolyphaseFilterBank<C> {
+    fn into_guts(self) -> Self::Guts {
+        self.config
+    }
+}
+
+impl<C> Reset for PolyphaseFilterBank<C> {
+    fn reset(self) -> Self {
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, PolyphaseFilterBank, PolyphaseFilterBankArray, PolyphaseFilterBankRefMut};
+    use crate::traits::WithConfig;
+
+    #[test]
+    fn from_parts_accepts_phase_major_coefficients() {
+        let bank = PolyphaseFilterBankArray::<i32, 6>::from_parts(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+
+        assert_eq!(bank.num_phases(), 3);
+        assert_eq!(bank.taps_per_phase(), 2);
+        assert_eq!(bank.total_taps(), 6);
+        assert_eq!(bank.phase_coefficients(0), &[1, 4]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 5]);
+        assert_eq!(bank.phase_coefficients(2), &[3, 6]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn from_prototype_taps_reorders_and_pads() {
+        use super::PolyphaseFilterBankVec;
+
+        let bank = PolyphaseFilterBankVec::<i32>::from_prototype_taps(3, &[1, 2, 3, 4, 5]);
+
+        assert_eq!(bank.num_phases(), 3);
+        assert_eq!(bank.taps_per_phase(), 2);
+        assert_eq!(bank.config.coefficients.as_slice(), &[1, 4, 2, 5, 3, 0]);
+        assert_eq!(bank.phase_coefficients(0), &[1, 4]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 5]);
+        assert_eq!(bank.phase_coefficients(2), &[3, 0]);
+    }
+
+    #[test]
+    fn with_config_accepts_phase_major_coefficients() {
+        let bank = PolyphaseFilterBank::<[i32; 4]>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        assert_eq!(bank.phase_coefficients(0), &[1, 3]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 4]);
+    }
+
+    #[test]
+    fn execute_uses_normal_convolution_order() {
+        let bank = PolyphaseFilterBankArray::<i32, 6>::from_parts(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+
+        assert_eq!(bank.execute(0, [10, 40].iter()), 80);
+        assert_eq!(bank.execute(1, [20, 50].iter()), 200);
+        assert_eq!(bank.execute(2, [30, 60].iter()), 360);
+    }
+
+    #[test]
+    #[should_panic(expected = "phase index out of range")]
+    fn execute_phase_out_of_range_panics() {
+        let bank = PolyphaseFilterBankArray::<i32, 4>::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let _ = bank.execute(2, [10, 20].iter());
+    }
+
+    #[test]
+    #[should_panic(expected = "taps count must equal taps_per_phase")]
+    fn execute_taps_count_mismatch_panics() {
+        let bank = PolyphaseFilterBankArray::<i32, 4>::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let _ = bank.execute(0, [10].iter());
+    }
+
+    #[test]
+    fn ref_mut_uses_caller_owned_phase_major_coefficients() {
+        let mut coefficients = [1, 3, 2, 4];
+        let bank: PolyphaseFilterBankRefMut<'_, i32> = PolyphaseFilterBank::from_parts(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: &mut coefficients[..],
+        });
+
+        assert_eq!(bank.phase_coefficients(0), &[1, 3]);
+        assert_eq!(bank.phase_coefficients(1), &[2, 4]);
+    }
+}

--- a/src/filters/fir/polyphase/fir.rs
+++ b/src/filters/fir/polyphase/fir.rs
@@ -1,0 +1,501 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Stateful polyphase FIR phase executor.
+
+use core::marker::PhantomData;
+use core::ops::{Add, Mul};
+
+use circular_buffer::{CircularBuffer, FixedCircularBuffer};
+use num_traits::{Num, Zero};
+
+use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, Reset, State as StateTrait, StateMut,
+    WithConfig,
+};
+
+use super::filter_bank::{Config, PolyphaseFilterBank};
+
+#[cfg(feature = "alloc")]
+use circular_buffer::HeapCircularBuffer;
+
+#[cfg(feature = "alloc")]
+use super::filter_bank::PolyphaseFilterBankVec;
+
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+
+/// The polyphase FIR executor's state.
+///
+/// Holds the delay line used by all phase branches.
+#[derive(Clone, Debug)]
+pub struct State<R> {
+    /// Buffered input samples used as the delay line.
+    pub taps: R,
+}
+
+/// A stateful polyphase FIR executor.
+///
+/// This type combines a [`PolyphaseFilterBank`] with one delay line. Call
+/// [`push`](Self::push) to append a new input sample, then
+/// [`execute`](Self::execute) to evaluate any phase against the current delay
+/// state.
+///
+/// # Coefficient ordering
+///
+/// Coefficients use the same phase-major ordering and execution semantics as
+/// [`PolyphaseFilterBank`]. This type keeps sample history and supplies it to
+/// the bank when [`Self::execute`] is called.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`PolyphaseFirArray<T, N, H, K>`] for stack-allocated coefficients and
+///   delay-line storage.
+#[cfg_attr(
+    feature = "alloc",
+    doc = "- [`PolyphaseFirVec<T, K>`] for heap-allocated coefficients and delay-line storage."
+)]
+#[cfg_attr(
+    not(feature = "alloc"),
+    doc = "- `PolyphaseFirVec<T, K>` for heap-allocated coefficients and delay-line storage."
+)]
+/// - [`PolyphaseFirRefMut<'_, T, C, K>`] for caller-owned delay-line storage.
+#[derive(Clone, Debug)]
+pub struct PolyphaseFir<T, C, R, K = T> {
+    bank: PolyphaseFilterBank<C>,
+    state: State<R>,
+    _pd: PhantomData<(T, K)>,
+}
+
+/// A polyphase FIR executor backed by fixed coefficient and delay-line storage.
+///
+/// `N` is the total coefficient count. `H` is the number of coefficients in
+/// each phase branch and must match the configuration's `taps_per_phase`.
+pub type PolyphaseFirArray<T, const N: usize, const H: usize, K = T> =
+    PolyphaseFir<T, [K; N], FixedCircularBuffer<T, H>, K>;
+
+/// A polyphase FIR executor backed by heap-allocated storage.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub type PolyphaseFirVec<T, K = T> = PolyphaseFir<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
+
+/// A polyphase FIR executor that borrows caller-owned delay-line storage.
+pub type PolyphaseFirRefMut<'a, T, C, K = T> = PolyphaseFir<T, C, &'a mut CircularBuffer<T>, K>;
+
+impl<T, C, R, K> PolyphaseFir<T, C, R, K>
+where
+    C: AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    /// Creates a [`PolyphaseFir`] from an already-constructed `config` and
+    /// delay-line buffer.
+    ///
+    /// Use this constructor when the delay-line storage is caller-owned or must
+    /// be constructed with a runtime capacity.
+    ///
+    /// The delay-line buffer is taken as-is with its current contents. It must
+    /// contain `taps_per_phase` samples before [`Self::execute`] is called.
+    ///
+    /// # Expected storage state
+    ///
+    /// For zero-padded cold-start behavior, prefill the buffer with
+    /// `taps_per_phase` zeros before passing it here.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the delay-line capacity does not equal the config's
+    /// `taps_per_phase`.
+    pub fn from_parts(config: Config<C>, taps: R) -> Self {
+        let bank = PolyphaseFilterBank::from_parts(config);
+        assert_eq!(
+            taps.capacity(),
+            bank.taps_per_phase(),
+            "PolyphaseFir: taps capacity must equal taps_per_phase"
+        );
+
+        Self {
+            bank,
+            state: State { taps },
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T, C, R, K> PolyphaseFir<T, C, R, K>
+where
+    R: RingBuffer<T>,
+{
+    /// Appends a new input sample to the delay line.
+    pub fn push(&mut self, input: T) {
+        let _ = self.state.taps.push_back(input);
+    }
+}
+
+impl<T, C, R, K> PolyphaseFir<T, C, R, K>
+where
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    /// Evaluates `phase` against the current delay line.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `phase >= self.num_phases()`, or if the current delay-line
+    /// length does not equal `self.taps_per_phase()`.
+    #[must_use]
+    pub fn execute(&self, phase: usize) -> T {
+        self.bank.execute(phase, self.state.taps.iter())
+    }
+}
+
+impl<T, C, R, K> PolyphaseFir<T, C, R, K> {
+    /// Returns the number of polyphase branches.
+    #[must_use]
+    pub fn num_phases(&self) -> usize {
+        self.bank.num_phases()
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.bank.taps_per_phase()
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.bank.total_taps()
+    }
+}
+
+impl<T, C, R, K> ConfigTrait for PolyphaseFir<T, C, R, K> {
+    type Config = Config<C>;
+}
+
+impl<T, const N: usize, const H: usize, K> WithConfig for PolyphaseFirArray<T, N, H, K>
+where
+    T: Num,
+{
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        let taps = zero_filled_fixed_ring::<T, H>();
+        Self::from_parts(config, taps)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, K> PolyphaseFirVec<T, K>
+where
+    T: Zero,
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed polyphase FIR executor from dense prototype
+    /// coefficients.
+    ///
+    /// This convenience constructor allocates coefficient and delay-line storage.
+    /// `prototype` is passed to
+    /// [`PolyphaseFilterBankVec::from_prototype_taps`] for ordering and padding
+    /// behavior. The delay line is zero-filled using the resulting
+    /// `taps_per_phase`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `num_phases` is zero, `prototype` is empty, or the padded
+    /// coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(num_phases: usize, prototype: &[K]) -> Self {
+        let bank = PolyphaseFilterBankVec::from_prototype_taps(num_phases, prototype);
+        let mut taps = HeapCircularBuffer::with_capacity(bank.taps_per_phase());
+        for _ in 0..bank.taps_per_phase() {
+            let _ = taps.push_back(T::zero());
+        }
+        Self::from_parts(bank.into_guts(), taps)
+    }
+}
+
+impl<T, C, R, K> ConfigRef for PolyphaseFir<T, C, R, K> {
+    fn config_ref(&self) -> &Self::Config {
+        self.bank.config_ref()
+    }
+}
+
+impl<T, C, R, K> ConfigClone for PolyphaseFir<T, C, R, K>
+where
+    Config<C>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.bank.config()
+    }
+}
+
+impl<T, C, R, K> StateTrait for PolyphaseFir<T, C, R, K> {
+    type State = State<R>;
+}
+
+impl<T, C, R, K> StateMut for PolyphaseFir<T, C, R, K> {
+    fn state_mut(&mut self) -> &mut Self::State {
+        &mut self.state
+    }
+}
+
+impl<T, C, R, K> HasGuts for PolyphaseFir<T, C, R, K> {
+    type Guts = (Config<C>, State<R>);
+}
+
+impl<T, C, R, K> FromGuts for PolyphaseFir<T, C, R, K> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        let (config, state) = guts;
+        Self {
+            bank: PolyphaseFilterBank::from_guts(config),
+            state,
+            _pd: PhantomData,
+        }
+    }
+}
+
+impl<T, C, R, K> IntoGuts for PolyphaseFir<T, C, R, K> {
+    fn into_guts(self) -> Self::Guts {
+        (self.bank.into_guts(), self.state)
+    }
+}
+
+impl<T, const N: usize, const H: usize, K> Reset for PolyphaseFirArray<T, N, H, K>
+where
+    T: Num,
+{
+    fn reset(self) -> Self {
+        Self::with_config(self.bank.into_guts())
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T, const N: usize, const H: usize, K> ResetMut for PolyphaseFirArray<T, N, H, K> where
+    Self: Reset
+{
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PolyphaseFir, PolyphaseFirArray, PolyphaseFirRefMut, State};
+    use crate::filters::fir::convolve::{Config as ConvolveConfig, ConvolveArray};
+    use crate::filters::fir::polyphase::filter_bank::Config;
+    use crate::traits::{
+        guts::{FromGuts, IntoGuts},
+        Filter, Reset, WithConfig,
+    };
+
+    #[test]
+    fn execute_uses_normal_convolution_order() {
+        let mut fir = PolyphaseFirArray::<i32, 6, 2>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+
+        assert_eq!(fir.num_phases(), 3);
+        assert_eq!(fir.taps_per_phase(), 2);
+        assert_eq!(fir.total_taps(), 6);
+
+        fir.push(10);
+        assert_eq!(fir.execute(0), 10);
+        assert_eq!(fir.execute(1), 20);
+        assert_eq!(fir.execute(2), 30);
+
+        fir.push(20);
+        assert_eq!(fir.execute(0), 60);
+        assert_eq!(fir.execute(1), 90);
+        assert_eq!(fir.execute(2), 120);
+    }
+
+    #[test]
+    fn each_phase_matches_convolve_with_same_phase_coefficients() {
+        let mut fir = PolyphaseFirArray::<i32, 6, 2>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 4, 2, 5, 3, 6],
+        });
+        let mut phase0 = ConvolveArray::<i32, 2>::with_config(ConvolveConfig {
+            coefficients: [1, 4],
+        });
+        let mut phase1 = ConvolveArray::<i32, 2>::with_config(ConvolveConfig {
+            coefficients: [2, 5],
+        });
+        let mut phase2 = ConvolveArray::<i32, 2>::with_config(ConvolveConfig {
+            coefficients: [3, 6],
+        });
+
+        for input in [10, 20, 30, 40] {
+            fir.push(input);
+            assert_eq!(fir.execute(0), phase0.filter(input));
+            assert_eq!(fir.execute(1), phase1.filter(input));
+            assert_eq!(fir.execute(2), phase2.filter(input));
+        }
+    }
+
+    #[cfg(feature = "complex")]
+    #[test]
+    fn real_taps_complex_samples_match_independent_real_filters() {
+        use approx::assert_abs_diff_eq;
+
+        use crate::complex::Complex32;
+
+        let coefficients = [0.5_f32, 0.125, -0.25, 0.0625];
+        let real_input = [1.0_f32, -2.0, 3.0, 5.0, -8.0];
+        let imag_input = [13.0_f32, -21.0, 34.0, -55.0, 89.0];
+
+        let mut real_filter = PolyphaseFirArray::<f32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut imag_filter = PolyphaseFirArray::<f32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut complex_filter = PolyphaseFirArray::<Complex32, 4, 2, f32>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+
+        for (&real, &imag) in real_input.iter().zip(&imag_input) {
+            real_filter.push(real);
+            imag_filter.push(imag);
+            complex_filter.push(Complex32::new(real, imag));
+
+            for phase in 0..2 {
+                let real_output = real_filter.execute(phase);
+                let imag_output = imag_filter.execute(phase);
+                let complex_output = complex_filter.execute(phase);
+
+                assert_abs_diff_eq!(complex_output.re, real_output, epsilon = 1e-6);
+                assert_abs_diff_eq!(complex_output.im, imag_output, epsilon = 1e-6);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "taps capacity must equal taps_per_phase")]
+    fn from_parts_capacity_mismatch_panics() {
+        let config = Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        };
+        let taps = circular_buffer::FixedCircularBuffer::<i32, 3>::new();
+
+        let _ = PolyphaseFir::from_parts(config, taps);
+    }
+
+    #[test]
+    #[should_panic(expected = "phase index out of range")]
+    fn execute_phase_out_of_range_panics() {
+        let fir = PolyphaseFirArray::<i32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let _ = fir.execute(2);
+    }
+
+    #[test]
+    fn reset_clears_delay_line() {
+        let mut fir = PolyphaseFirArray::<i32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        fir.push(10);
+        fir.push(20);
+        assert_eq!(fir.execute(0), 50);
+
+        let fir = fir.reset();
+        assert_eq!(fir.execute(0), 0);
+        assert_eq!(fir.execute(1), 0);
+    }
+
+    #[test]
+    fn ref_mut_uses_caller_owned_delay_line() {
+        let config = Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        };
+        let mut taps = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = taps.push_back(0);
+        let _ = taps.push_back(0);
+        let mut fir: PolyphaseFirRefMut<'_, i32, [i32; 4]> =
+            PolyphaseFir::from_parts(config, &mut taps);
+
+        fir.push(10);
+
+        assert_eq!(fir.execute(0), 10);
+        assert_eq!(fir.execute(1), 20);
+    }
+
+    #[test]
+    fn guts_round_trip_preserves_state() {
+        let mut fir = PolyphaseFirArray::<i32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        fir.push(10);
+        fir.push(20);
+
+        let guts = fir.into_guts();
+        let fir = PolyphaseFirArray::<i32, 4, 2>::from_guts(guts);
+
+        assert_eq!(fir.execute(0), 50);
+        assert_eq!(fir.execute(1), 80);
+    }
+
+    #[test]
+    fn from_guts_accepts_existing_state() {
+        let mut taps = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = taps.push_back(10);
+        let _ = taps.push_back(20);
+
+        let fir = PolyphaseFirArray::<i32, 4, 2>::from_guts((
+            Config {
+                num_phases: 2,
+                taps_per_phase: 2,
+                coefficients: [1, 3, 2, 4],
+            },
+            State { taps },
+        ));
+
+        assert_eq!(fir.execute(0), 50);
+        assert_eq!(fir.execute(1), 80);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec_from_prototype_taps_reorders_and_zero_fills_delay_line() {
+        let mut fir = super::PolyphaseFirVec::<i32>::from_prototype_taps(3, &[1, 2, 3, 4, 5]);
+
+        assert_eq!(fir.num_phases(), 3);
+        assert_eq!(fir.taps_per_phase(), 2);
+
+        fir.push(10);
+        assert_eq!(fir.execute(0), 10);
+        assert_eq!(fir.execute(1), 20);
+        assert_eq!(fir.execute(2), 30);
+
+        fir.push(20);
+        assert_eq!(fir.execute(0), 60);
+        assert_eq!(fir.execute(1), 90);
+        assert_eq!(fir.execute(2), 60);
+    }
+}

--- a/src/filters/fir/polyphase/interpolator.rs
+++ b/src/filters/fir/polyphase/interpolator.rs
@@ -1,0 +1,511 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR interpolation.
+
+use core::ops::{Add, Mul};
+
+use circular_buffer::{CircularBuffer, FixedCircularBuffer};
+use num_traits::{Num, Zero};
+
+use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, MultirateFilter, Reset, WithConfig,
+};
+
+use super::{
+    filter_bank::Config,
+    fir::{PolyphaseFir, PolyphaseFirArray},
+};
+
+#[cfg(feature = "alloc")]
+use circular_buffer::HeapCircularBuffer;
+
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+
+/// The polyphase interpolator's state.
+#[derive(Clone, Debug)]
+pub struct State {
+    /// The phase branch that will produce the next output sample.
+    ///
+    /// `phase == num_phases` means no phase output is pending.
+    pub phase: usize,
+}
+
+/// A stateful 1-to-P polyphase interpolator.
+///
+/// This type wraps [`PolyphaseFir`] and implements [`MultirateFilter`]. Each
+/// consumed input sample is pushed into the shared delay line, then phases
+/// `0..P` are evaluated in order.
+///
+/// The [`MultirateFilter::process`] implementation supports streaming operation
+/// with arbitrary input and output slice sizes. If the output buffer fills before
+/// all phases are produced, the next call resumes from the pending phase without
+/// consuming another input sample first.
+///
+/// An empty output slice consumes no input because every accepted input sample
+/// has phase outputs to produce.
+///
+/// The `phase` state starts at `num_phases`, which means no output is pending.
+/// After an input sample is consumed, `phase` advances upward from zero until
+/// all phases for that sample have been produced.
+///
+/// Coefficients follow the phase-major ordering described by
+/// [`PolyphaseFilterBank`](super::filter_bank::PolyphaseFilterBank).
+///
+/// # Gain
+///
+/// This type does not apply interpolation gain scaling. To preserve the input
+/// amplitude, the prototype filter must have passband gain equal to the
+/// interpolation factor. A unity-gain prototype therefore produces output
+/// attenuated by `1 / P`; multiply its coefficients by `P` before construction,
+/// or design the prototype with the required gain.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`PolyphaseInterpolatorArray<T, N, H, K>`] for stack-allocated
+///   coefficients and delay-line storage.
+#[cfg_attr(
+    feature = "alloc",
+    doc = "- [`PolyphaseInterpolatorVec<T, K>`] for heap-allocated coefficients and delay-line storage."
+)]
+#[cfg_attr(
+    not(feature = "alloc"),
+    doc = "- `PolyphaseInterpolatorVec<T, K>` for heap-allocated coefficients and delay-line storage."
+)]
+/// - [`PolyphaseInterpolatorRefMut<'_, T, C, K>`] for caller-owned delay-line
+///   storage.
+#[derive(Clone, Debug)]
+pub struct PolyphaseInterpolator<T, C, R, K = T> {
+    fir: PolyphaseFir<T, C, R, K>,
+    state: State,
+}
+
+/// A polyphase interpolator backed by fixed coefficient and delay-line storage.
+///
+/// `N` is the total coefficient count. `H` is the number of coefficients in
+/// each phase branch and must match the configuration's `taps_per_phase`.
+pub type PolyphaseInterpolatorArray<T, const N: usize, const H: usize, K = T> =
+    PolyphaseInterpolator<T, [K; N], FixedCircularBuffer<T, H>, K>;
+
+/// A polyphase interpolator backed by heap-allocated storage.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub type PolyphaseInterpolatorVec<T, K = T> =
+    PolyphaseInterpolator<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
+
+/// A polyphase interpolator that borrows caller-owned delay-line storage.
+pub type PolyphaseInterpolatorRefMut<'a, T, C, K = T> =
+    PolyphaseInterpolator<T, C, &'a mut CircularBuffer<T>, K>;
+
+impl<T, C, R, K> PolyphaseInterpolator<T, C, R, K>
+where
+    C: AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    /// Creates a [`PolyphaseInterpolator`] from an already-constructed `config`
+    /// and delay-line buffer.
+    ///
+    /// Use this constructor when the delay-line storage is caller-owned or must
+    /// be constructed with a runtime capacity.
+    ///
+    /// The delay-line buffer is taken as-is with its current contents. It must
+    /// contain `taps_per_phase` samples before the first phase is evaluated.
+    ///
+    /// # Expected storage state
+    ///
+    /// For zero-padded cold-start behavior, prefill the buffer with
+    /// `taps_per_phase` zeros before passing it here.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config.num_phases` or `config.taps_per_phase` is zero, if the
+    /// coefficient count does not equal `config.num_phases *
+    /// config.taps_per_phase`, or if the delay-line capacity does not equal
+    /// `config.taps_per_phase`.
+    pub fn from_parts(config: Config<C>, taps: R) -> Self {
+        Self::from_fir(PolyphaseFir::from_parts(config, taps))
+    }
+}
+
+impl<T, C, R, K> PolyphaseInterpolator<T, C, R, K> {
+    fn from_fir(fir: PolyphaseFir<T, C, R, K>) -> Self {
+        Self {
+            state: State {
+                phase: fir.num_phases(),
+            },
+            fir,
+        }
+    }
+
+    /// Returns the number of polyphase branches and interpolation factor.
+    #[must_use]
+    pub fn num_phases(&self) -> usize {
+        self.fir.num_phases()
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.fir.taps_per_phase()
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.fir.total_taps()
+    }
+}
+
+impl<T, C, R, K> ConfigTrait for PolyphaseInterpolator<T, C, R, K> {
+    type Config = Config<C>;
+}
+
+impl<T, const N: usize, const H: usize, K> WithConfig for PolyphaseInterpolatorArray<T, N, H, K>
+where
+    T: Num,
+{
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        Self::from_parts(config, zero_filled_fixed_ring::<T, H>())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, K> PolyphaseInterpolatorVec<T, K>
+where
+    T: Zero,
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed polyphase interpolator from dense prototype
+    /// coefficients.
+    ///
+    /// This convenience constructor allocates coefficient and delay-line storage.
+    /// `prototype` is passed to
+    /// [`PolyphaseFirVec::from_prototype_taps`](super::fir::PolyphaseFirVec::from_prototype_taps)
+    /// for ordering and padding behavior.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interpolation` is zero, `prototype` is empty, or the padded
+    /// coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(interpolation: usize, prototype: &[K]) -> Self {
+        Self::from_fir(super::fir::PolyphaseFirVec::from_prototype_taps(
+            interpolation,
+            prototype,
+        ))
+    }
+}
+
+impl<T, C, R, K> ConfigRef for PolyphaseInterpolator<T, C, R, K> {
+    fn config_ref(&self) -> &Self::Config {
+        self.fir.config_ref()
+    }
+}
+
+impl<T, C, R, K> ConfigClone for PolyphaseInterpolator<T, C, R, K>
+where
+    Config<C>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.fir.config()
+    }
+}
+
+impl<T, C, R, K> HasGuts for PolyphaseInterpolator<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: HasGuts,
+{
+    type Guts = (<PolyphaseFir<T, C, R, K> as HasGuts>::Guts, State);
+}
+
+impl<T, C, R, K> FromGuts for PolyphaseInterpolator<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: FromGuts + HasGuts,
+{
+    fn from_guts(guts: Self::Guts) -> Self {
+        let (fir, state) = guts;
+        Self {
+            fir: PolyphaseFir::from_guts(fir),
+            state,
+        }
+    }
+}
+
+impl<T, C, R, K> IntoGuts for PolyphaseInterpolator<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: IntoGuts + HasGuts,
+{
+    fn into_guts(self) -> Self::Guts {
+        (self.fir.into_guts(), self.state)
+    }
+}
+
+impl<T, const N: usize, const H: usize, K> Reset for PolyphaseInterpolatorArray<T, N, H, K>
+where
+    PolyphaseFirArray<T, N, H, K>: Reset,
+{
+    fn reset(self) -> Self {
+        Self::from_fir(self.fir.reset())
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T, const N: usize, const H: usize, K> ResetMut for PolyphaseInterpolatorArray<T, N, H, K> where
+    Self: Reset
+{
+}
+
+impl<T, C, R, K> MultirateFilter<T> for PolyphaseInterpolator<T, C, R, K>
+where
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    type Output = T;
+
+    fn process(&mut self, input: &[T], output: &mut [Self::Output]) -> (usize, usize) {
+        let mut input_consumed = 0;
+        let mut output_produced = 0;
+        let num_phases = self.num_phases();
+
+        while output_produced < output.len() {
+            if self.state.phase == num_phases {
+                if input_consumed == input.len() {
+                    break;
+                }
+
+                self.fir.push(input[input_consumed].clone());
+                input_consumed += 1;
+                self.state.phase = 0;
+            }
+
+            output[output_produced] = self.fir.execute(self.state.phase);
+            output_produced += 1;
+            self.state.phase += 1;
+        }
+
+        (input_consumed, output_produced)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PolyphaseInterpolator, PolyphaseInterpolatorArray, PolyphaseInterpolatorRefMut};
+    use crate::filters::fir::polyphase::filter_bank::Config;
+    use crate::traits::{
+        guts::{FromGuts, IntoGuts},
+        MultirateFilter, Reset, WithConfig,
+    };
+
+    #[test]
+    fn process_interpolates_all_phases() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+        let input = [10, 20];
+        let mut output = [0; 6];
+
+        assert_eq!(interpolator.process(&input, &mut output), (2, 6));
+        assert_eq!(output, [10, 20, 30, 20, 40, 60]);
+    }
+
+    #[test]
+    fn process_resumes_pending_phases_before_consuming_input() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+        let input = [10, 20];
+        let mut first_output = [0; 2];
+        let mut second_output = [0; 4];
+
+        assert_eq!(interpolator.process(&input, &mut first_output), (1, 2));
+        assert_eq!(first_output, [10, 20]);
+
+        assert_eq!(
+            interpolator.process(&input[1..], &mut second_output),
+            (1, 4)
+        );
+        assert_eq!(second_output, [30, 20, 40, 60]);
+    }
+
+    #[test]
+    fn process_can_drain_pending_output_without_new_input() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+        let input = [10];
+        let mut first_output = [0; 1];
+        let mut second_output = [0; 2];
+
+        assert_eq!(interpolator.process(&input, &mut first_output), (1, 1));
+        assert_eq!(first_output, [10]);
+
+        assert_eq!(interpolator.process(&[], &mut second_output), (0, 2));
+        assert_eq!(second_output, [20, 30]);
+    }
+
+    #[test]
+    fn empty_output_consumes_no_input() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+
+        assert_eq!(interpolator.process(&[10], &mut []), (0, 0));
+    }
+
+    #[test]
+    fn multi_tap_phases_use_fir_history() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let input = [10, 20, 30];
+        let mut output = [0; 6];
+
+        assert_eq!(interpolator.process(&input, &mut output), (3, 6));
+        assert_eq!(output, [10, 20, 50, 80, 90, 140]);
+    }
+
+    #[cfg(feature = "complex")]
+    #[test]
+    fn real_taps_complex_samples_match_independent_real_interpolators() {
+        use approx::assert_abs_diff_eq;
+
+        use crate::complex::Complex32;
+
+        let coefficients = [0.5_f32, -0.25, 0.125, 0.0625];
+        let real_input = [1.0_f32, -2.0, 3.0];
+        let imag_input = [5.0_f32, -8.0, 13.0];
+        let complex_input = [
+            Complex32::new(real_input[0], imag_input[0]),
+            Complex32::new(real_input[1], imag_input[1]),
+            Complex32::new(real_input[2], imag_input[2]),
+        ];
+        let mut real_interpolator = PolyphaseInterpolatorArray::<f32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut imag_interpolator = PolyphaseInterpolatorArray::<f32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut complex_interpolator =
+            PolyphaseInterpolatorArray::<Complex32, 4, 2, f32>::with_config(Config {
+                num_phases: 2,
+                taps_per_phase: 2,
+                coefficients,
+            });
+        let mut real_output = [0.0; 6];
+        let mut imag_output = [0.0; 6];
+        let mut complex_output = [Complex32::new(0.0, 0.0); 6];
+
+        assert_eq!(
+            real_interpolator.process(&real_input, &mut real_output),
+            (3, 6)
+        );
+        assert_eq!(
+            imag_interpolator.process(&imag_input, &mut imag_output),
+            (3, 6)
+        );
+        assert_eq!(
+            complex_interpolator.process(&complex_input, &mut complex_output),
+            (3, 6)
+        );
+
+        for ((complex, real), imag) in complex_output
+            .iter()
+            .zip(real_output.iter())
+            .zip(imag_output.iter())
+        {
+            assert_abs_diff_eq!(complex.re, *real, epsilon = 1e-6);
+            assert_abs_diff_eq!(complex.im, *imag, epsilon = 1e-6);
+        }
+    }
+
+    #[test]
+    fn reset_clears_pending_phase_and_taps() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 4, 2>::with_config(Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let mut output = [0; 1];
+
+        assert_eq!(interpolator.process(&[10], &mut output), (1, 1));
+        assert_eq!(output, [10]);
+
+        let mut interpolator = interpolator.reset();
+        let mut output = [0; 2];
+
+        assert_eq!(interpolator.process(&[20], &mut output), (1, 2));
+        assert_eq!(output, [20, 40]);
+    }
+
+    #[test]
+    fn ref_mut_uses_caller_owned_delay_line() {
+        let config = Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        };
+        let mut taps = circular_buffer::FixedCircularBuffer::<i32, 2>::new();
+        let _ = taps.push_back(0);
+        let _ = taps.push_back(0);
+        let mut interpolator: PolyphaseInterpolatorRefMut<'_, i32, [i32; 4]> =
+            PolyphaseInterpolator::from_parts(config, &mut taps);
+        let mut output = [0; 2];
+
+        assert_eq!(interpolator.process(&[10], &mut output), (1, 2));
+        assert_eq!(output, [10, 20]);
+    }
+
+    #[test]
+    fn guts_round_trip_preserves_pending_phase() {
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::with_config(Config {
+            num_phases: 3,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+        let mut first_output = [0; 1];
+        assert_eq!(interpolator.process(&[10], &mut first_output), (1, 1));
+
+        let guts = interpolator.into_guts();
+        let mut interpolator = PolyphaseInterpolatorArray::<i32, 3, 1>::from_guts(guts);
+        let mut second_output = [0; 2];
+
+        assert_eq!(interpolator.process(&[], &mut second_output), (0, 2));
+        assert_eq!(second_output, [20, 30]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec_from_prototype_taps_interpolates() {
+        let mut interpolator =
+            super::PolyphaseInterpolatorVec::<i32>::from_prototype_taps(2, &[1, 2, 3, 4]);
+        let input = [10, 20];
+        let mut output = [0; 4];
+
+        assert_eq!(interpolator.process(&input, &mut output), (2, 4));
+        assert_eq!(output, [10, 20, 50, 80]);
+    }
+}

--- a/src/filters/fir/polyphase/rational_resampler.rs
+++ b/src/filters/fir/polyphase/rational_resampler.rs
@@ -1,0 +1,612 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Polyphase FIR rational resampling.
+
+use core::ops::{Add, Mul};
+
+use circular_buffer::{CircularBuffer, FixedCircularBuffer};
+use num_traits::{Num, Zero};
+
+use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, MultirateFilter, Reset, WithConfig,
+};
+
+use super::{
+    filter_bank::Config as BankConfig,
+    fir::{PolyphaseFir, PolyphaseFirArray},
+};
+
+#[cfg(feature = "alloc")]
+use circular_buffer::HeapCircularBuffer;
+
+#[cfg(feature = "alloc")]
+use super::fir::PolyphaseFirVec;
+
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+
+/// The rational resampler's configuration.
+#[derive(Clone, Debug)]
+pub struct Config<C> {
+    /// Interpolation factor and number of coefficient phases.
+    pub interpolation: usize,
+    /// Decimation factor.
+    pub decimation: usize,
+    /// Number of coefficients in each phase branch.
+    pub taps_per_phase: usize,
+    /// Coefficients in the phase-major layout described by
+    /// [`PolyphaseFilterBank`](super::filter_bank::PolyphaseFilterBank),
+    /// with `interpolation` phases.
+    pub coefficients: C,
+}
+
+/// The rational resampler's state.
+#[derive(Clone, Debug)]
+pub struct State {
+    /// Phase accumulator.
+    ///
+    /// `phase < interpolation` means an output is pending for the current delay
+    /// state. `phase >= interpolation` means input must be consumed before the
+    /// next output can be produced.
+    pub phase: usize,
+}
+
+/// A stateful `P`/`Q` polyphase rational resampler.
+///
+/// This type wraps [`PolyphaseFir`] and implements [`MultirateFilter`] using a
+/// phase accumulator. The interpolation factor is the wrapped FIR's number of
+/// phases. `decimation` is the phase increment after each produced output.
+///
+/// The first input sample is consumed before the first output is produced. This
+/// matches the usual `upfirdn` timing where outputs are taken from indices
+/// `0, Q, 2Q, ...` of the upsampled-and-filtered sequence.
+///
+/// Coefficients follow the phase-major ordering described by
+/// [`PolyphaseFilterBank`](super::filter_bank::PolyphaseFilterBank).
+///
+/// # Gain
+///
+/// This type does not apply interpolation gain scaling. To preserve the input
+/// amplitude, the prototype filter must have passband gain equal to the
+/// interpolation factor. A unity-gain prototype therefore produces output
+/// attenuated by `1 / P`; multiply its coefficients by `P` before construction,
+/// or design the prototype with the required gain.
+///
+/// # Ratio reduction
+///
+/// The interpolation and decimation factors are used exactly as supplied; they
+/// are not reduced by their greatest common divisor. If the factors share a
+/// divisor, only the corresponding subset of phases is reached by the phase
+/// accumulator, so the unreduced form may store redundant phase branches. Pass
+/// reduced factors and coefficients packed for that reduced phase count when
+/// minimal storage is required.
+///
+/// # Streaming
+///
+/// The [`MultirateFilter::process`] implementation supports streaming operation
+/// with arbitrary input and output slice sizes. When output capacity is full,
+/// the resampler can still consume input while advancing its phase accumulator
+/// until the next output is pending. Once an output is pending, it consumes no
+/// further input until that output is emitted. Pass the unconsumed input suffix
+/// to the next call.
+///
+/// # Type aliases
+///
+/// Prefer the concrete aliases for common use:
+/// - [`RationalResamplerArray<T, N, H, K>`] for stack-allocated coefficients
+///   and delay-line storage.
+#[cfg_attr(
+    feature = "alloc",
+    doc = "- [`RationalResamplerVec<T, K>`] for heap-allocated coefficients and delay-line storage."
+)]
+#[cfg_attr(
+    not(feature = "alloc"),
+    doc = "- `RationalResamplerVec<T, K>` for heap-allocated coefficients and delay-line storage."
+)]
+/// - [`RationalResamplerRefMut<'_, T, C, K>`] for caller-owned delay-line
+///   storage.
+#[derive(Clone, Debug)]
+pub struct RationalResampler<T, C, R, K = T> {
+    fir: PolyphaseFir<T, C, R, K>,
+    decimation: usize,
+    state: State,
+}
+
+/// A rational resampler backed by fixed coefficient and delay-line storage.
+///
+/// `N` is the total coefficient count. `H` is the number of coefficients in
+/// each phase branch and must match the configuration's `taps_per_phase`.
+pub type RationalResamplerArray<T, const N: usize, const H: usize, K = T> =
+    RationalResampler<T, [K; N], FixedCircularBuffer<T, H>, K>;
+
+/// A rational resampler backed by heap-allocated storage.
+///
+/// Requires the `alloc` feature.
+#[cfg(feature = "alloc")]
+pub type RationalResamplerVec<T, K = T> =
+    RationalResampler<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
+
+/// A rational resampler that borrows caller-owned delay-line storage.
+pub type RationalResamplerRefMut<'a, T, C, K = T> =
+    RationalResampler<T, C, &'a mut CircularBuffer<T>, K>;
+
+impl<T, C, R, K> RationalResampler<T, C, R, K>
+where
+    C: AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    /// Creates a [`RationalResampler`] from an already-constructed `config` and
+    /// delay-line buffer.
+    ///
+    /// Use this constructor when the delay-line storage is caller-owned or must
+    /// be constructed with a runtime capacity.
+    ///
+    /// The delay-line buffer is taken as-is with its current contents. It must
+    /// contain `taps_per_phase` samples before the first output is produced.
+    ///
+    /// # Expected storage state
+    ///
+    /// For zero-padded cold-start behavior, prefill the buffer with
+    /// `taps_per_phase` zeros before passing it here.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config.decimation` is zero, if `config.interpolation` or
+    /// `config.taps_per_phase` is zero, if the coefficient count does not equal
+    /// `config.interpolation * config.taps_per_phase`, or if the delay-line
+    /// capacity does not equal `config.taps_per_phase`.
+    pub fn from_parts(config: Config<C>, taps: R) -> Self {
+        assert!(
+            config.decimation > 0,
+            "RationalResampler: decimation must be > 0"
+        );
+        let decimation = config.decimation;
+        let fir = PolyphaseFir::from_parts(
+            BankConfig {
+                num_phases: config.interpolation,
+                taps_per_phase: config.taps_per_phase,
+                coefficients: config.coefficients,
+            },
+            taps,
+        );
+        Self::from_fir(fir, decimation)
+    }
+}
+
+impl<T, C, R, K> RationalResampler<T, C, R, K> {
+    fn from_fir(fir: PolyphaseFir<T, C, R, K>, decimation: usize) -> Self {
+        assert!(decimation > 0, "RationalResampler: decimation must be > 0");
+        Self {
+            state: State {
+                phase: fir.num_phases(),
+            },
+            fir,
+            decimation,
+        }
+    }
+
+    /// Returns the interpolation factor.
+    #[must_use]
+    pub fn interpolation(&self) -> usize {
+        self.fir.num_phases()
+    }
+
+    /// Returns the decimation factor.
+    #[must_use]
+    pub fn decimation(&self) -> usize {
+        self.decimation
+    }
+
+    /// Returns the number of coefficients in each phase branch.
+    #[must_use]
+    pub fn taps_per_phase(&self) -> usize {
+        self.fir.taps_per_phase()
+    }
+
+    /// Returns the total number of coefficients.
+    #[must_use]
+    pub fn total_taps(&self) -> usize {
+        self.fir.total_taps()
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, K> RationalResamplerVec<T, K>
+where
+    T: Zero,
+    K: Clone + Zero,
+{
+    /// Creates a heap-backed rational resampler from dense prototype
+    /// coefficients.
+    ///
+    /// This convenience constructor allocates coefficient and delay-line storage.
+    /// `prototype` is passed to
+    /// [`PolyphaseFilterBankVec::from_prototype_taps`](super::filter_bank::PolyphaseFilterBankVec::from_prototype_taps)
+    /// using the supplied interpolation factor for ordering and padding
+    /// behavior. The ratio is not reduced before packing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `interpolation` or `decimation` is zero, `prototype` is empty,
+    /// or the padded coefficient count overflows `usize`.
+    #[must_use]
+    pub fn from_prototype_taps(interpolation: usize, decimation: usize, prototype: &[K]) -> Self {
+        Self::from_fir(
+            PolyphaseFirVec::from_prototype_taps(interpolation, prototype),
+            decimation,
+        )
+    }
+}
+
+impl<T, C, R, K> ConfigTrait for RationalResampler<T, C, R, K> {
+    type Config = Config<C>;
+}
+
+impl<T, const N: usize, const H: usize, K> WithConfig for RationalResamplerArray<T, N, H, K>
+where
+    T: Num,
+{
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        Self::from_parts(config, zero_filled_fixed_ring::<T, H>())
+    }
+}
+
+impl<T, C, R, K> ConfigClone for RationalResampler<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: ConfigClone<Config = BankConfig<C>>,
+{
+    fn config(&self) -> Self::Config {
+        let bank = self.fir.config();
+        Config {
+            interpolation: bank.num_phases,
+            decimation: self.decimation,
+            taps_per_phase: bank.taps_per_phase,
+            coefficients: bank.coefficients,
+        }
+    }
+}
+
+impl<T, C, R, K> HasGuts for RationalResampler<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: HasGuts,
+{
+    type Guts = (<PolyphaseFir<T, C, R, K> as HasGuts>::Guts, usize, State);
+}
+
+impl<T, C, R, K> FromGuts for RationalResampler<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: FromGuts + HasGuts,
+{
+    fn from_guts(guts: Self::Guts) -> Self {
+        let (fir, decimation, state) = guts;
+        assert!(decimation > 0, "RationalResampler: decimation must be > 0");
+        Self {
+            fir: PolyphaseFir::from_guts(fir),
+            decimation,
+            state,
+        }
+    }
+}
+
+impl<T, C, R, K> IntoGuts for RationalResampler<T, C, R, K>
+where
+    PolyphaseFir<T, C, R, K>: IntoGuts + HasGuts,
+{
+    fn into_guts(self) -> Self::Guts {
+        (self.fir.into_guts(), self.decimation, self.state)
+    }
+}
+
+impl<T, const N: usize, const H: usize, K> Reset for RationalResamplerArray<T, N, H, K>
+where
+    PolyphaseFirArray<T, N, H, K>: Reset,
+{
+    fn reset(self) -> Self {
+        Self::from_fir(self.fir.reset(), self.decimation)
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T, const N: usize, const H: usize, K> ResetMut for RationalResamplerArray<T, N, H, K> where
+    Self: Reset
+{
+}
+
+impl<T, C, R, K> MultirateFilter<T> for RationalResampler<T, C, R, K>
+where
+    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+    K: Clone,
+    C: crate::storage::AsSlice<K>,
+    R: RingBuffer<T>,
+{
+    type Output = T;
+
+    fn process(&mut self, input: &[T], output: &mut [Self::Output]) -> (usize, usize) {
+        let mut input_consumed = 0;
+        let mut output_produced = 0;
+        let interpolation = self.interpolation();
+
+        loop {
+            if self.state.phase >= interpolation {
+                if input_consumed == input.len() {
+                    break;
+                }
+
+                self.fir.push(input[input_consumed].clone());
+                input_consumed += 1;
+                self.state.phase -= interpolation;
+                continue;
+            }
+
+            if output_produced == output.len() {
+                break;
+            }
+
+            output[output_produced] = self.fir.execute(self.state.phase);
+            output_produced += 1;
+            self.state.phase += self.decimation;
+        }
+
+        (input_consumed, output_produced)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "alloc")]
+    use super::RationalResamplerVec;
+    use super::{Config, RationalResamplerArray};
+    use crate::filters::fir::convolve::{Config as ConvolveConfig, ConvolveArray};
+    use crate::traits::{
+        guts::{FromGuts, IntoGuts},
+        ConfigClone, Filter, MultirateFilter, Reset, WithConfig,
+    };
+
+    #[test]
+    fn process_resamples_known_ratio() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let input = [10, 20, 30, 40];
+        let mut output = [0; 3];
+
+        assert_eq!(resampler.process(&input, &mut output), (4, 3));
+        assert_eq!(output, [10, 80, 130]);
+    }
+
+    #[test]
+    fn process_matches_upsample_convolve_then_downsample() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let mut convolve = ConvolveArray::<i32, 4>::with_config(ConvolveConfig {
+            coefficients: [1, 2, 3, 4],
+        });
+        let input = [10, 20, 30, 40, 50, 60];
+        let mut expected = [0; 4];
+        let mut expected_len = 0;
+
+        for (index, sample) in input
+            .iter()
+            .copied()
+            .flat_map(|sample| [sample, 0])
+            .enumerate()
+        {
+            let output = convolve.filter(sample);
+            if index % 3 == 0 {
+                expected[expected_len] = output;
+                expected_len += 1;
+            }
+        }
+
+        let mut output = [0; 4];
+        assert_eq!(resampler.process(&input, &mut output), (6, 4));
+        assert_eq!(expected_len, output.len());
+        assert_eq!(output, expected);
+    }
+
+    #[test]
+    fn process_can_resume_with_pending_output() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let input = [10, 20, 30, 40];
+        let mut first_output = [0; 1];
+        let mut second_output = [0; 1];
+        let mut third_output = [0; 1];
+
+        assert_eq!(resampler.process(&input, &mut first_output), (2, 1));
+        assert_eq!(first_output, [10]);
+
+        assert_eq!(resampler.process(&input[2..], &mut second_output), (2, 1));
+        assert_eq!(second_output, [80]);
+
+        assert_eq!(resampler.process(&[], &mut third_output), (0, 1));
+        assert_eq!(third_output, [130]);
+    }
+
+    #[test]
+    fn interpolation_only_matches_interpolator_timing() {
+        let mut resampler = RationalResamplerArray::<i32, 3, 1>::with_config(Config {
+            interpolation: 3,
+            decimation: 1,
+            taps_per_phase: 1,
+            coefficients: [1, 2, 3],
+        });
+        let input = [10, 20];
+        let mut output = [0; 6];
+
+        assert_eq!(resampler.process(&input, &mut output), (2, 6));
+        assert_eq!(output, [10, 20, 30, 20, 40, 60]);
+    }
+
+    #[test]
+    fn decimation_only_uses_upfirdn_output_phase() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 4>::with_config(Config {
+            interpolation: 1,
+            decimation: 3,
+            taps_per_phase: 4,
+            coefficients: [1, 2, 3, 4],
+        });
+        let input = [10, 20, 30, 40, 50];
+        let mut output = [0; 2];
+
+        assert_eq!(resampler.process(&input, &mut output), (5, 2));
+        assert_eq!(output, [10, 200]);
+    }
+
+    #[test]
+    fn empty_output_can_consume_until_next_output_is_pending() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let mut output = [0; 1];
+
+        assert_eq!(resampler.process(&[10], &mut []), (1, 0));
+        assert_eq!(resampler.process(&[], &mut output), (0, 1));
+        assert_eq!(output, [10]);
+    }
+
+    #[test]
+    fn reset_clears_delay_line_and_phase() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        let mut output = [0; 1];
+
+        assert_eq!(resampler.process(&[10, 20], &mut output), (2, 1));
+        let mut resampler = resampler.reset();
+
+        assert_eq!(resampler.process(&[10], &mut output), (1, 1));
+        assert_eq!(output, [10]);
+    }
+
+    #[test]
+    fn guts_round_trip_preserves_pending_phase() {
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+        assert_eq!(resampler.process(&[10], &mut []), (1, 0));
+
+        let guts = resampler.into_guts();
+        let mut resampler = RationalResamplerArray::<i32, 4, 2>::from_guts(guts);
+        let mut output = [0; 1];
+
+        assert_eq!(resampler.process(&[], &mut output), (0, 1));
+        assert_eq!(output, [10]);
+    }
+
+    #[test]
+    fn config_clone_preserves_resampling_config() {
+        let resampler = RationalResamplerArray::<i32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients: [1, 3, 2, 4],
+        });
+
+        let config = resampler.config();
+        assert_eq!(config.interpolation, 2);
+        assert_eq!(config.decimation, 3);
+        assert_eq!(config.taps_per_phase, 2);
+        assert_eq!(config.coefficients, [1, 3, 2, 4]);
+    }
+
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec_from_prototype_taps_resamples() {
+        let mut resampler = RationalResamplerVec::<i32>::from_prototype_taps(2, 3, &[1, 2, 3, 4]);
+        let input = [10, 20, 30, 40];
+        let mut output = [0; 3];
+
+        assert_eq!(resampler.process(&input, &mut output), (4, 3));
+        assert_eq!(output, [10, 80, 130]);
+    }
+
+    #[cfg(feature = "complex")]
+    #[test]
+    fn real_taps_complex_samples_match_independent_real_resamplers() {
+        use approx::assert_abs_diff_eq;
+
+        use crate::complex::Complex32;
+
+        let coefficients = [0.5_f32, 0.125, -0.25, 0.0625];
+        let real_input = [1.0_f32, -2.0, 3.0, 5.0, -8.0];
+        let imag_input = [13.0_f32, -21.0, 34.0, -55.0, 89.0];
+        let complex_input = [
+            Complex32::new(real_input[0], imag_input[0]),
+            Complex32::new(real_input[1], imag_input[1]),
+            Complex32::new(real_input[2], imag_input[2]),
+            Complex32::new(real_input[3], imag_input[3]),
+            Complex32::new(real_input[4], imag_input[4]),
+        ];
+        let mut real_resampler = RationalResamplerArray::<f32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut imag_resampler = RationalResamplerArray::<f32, 4, 2>::with_config(Config {
+            interpolation: 2,
+            decimation: 3,
+            taps_per_phase: 2,
+            coefficients,
+        });
+        let mut complex_resampler =
+            RationalResamplerArray::<Complex32, 4, 2, f32>::with_config(Config {
+                interpolation: 2,
+                decimation: 3,
+                taps_per_phase: 2,
+                coefficients,
+            });
+        let mut real_output = [0.0; 4];
+        let mut imag_output = [0.0; 4];
+        let mut complex_output = [Complex32::new(0.0, 0.0); 4];
+
+        assert_eq!(
+            real_resampler.process(&real_input, &mut real_output),
+            (5, 4)
+        );
+        assert_eq!(
+            imag_resampler.process(&imag_input, &mut imag_output),
+            (5, 4)
+        );
+        assert_eq!(
+            complex_resampler.process(&complex_input, &mut complex_output),
+            (5, 4)
+        );
+
+        for ((complex, real), imag) in complex_output
+            .iter()
+            .zip(real_output.iter())
+            .zip(imag_output.iter())
+        {
+            assert_abs_diff_eq!(complex.re, *real, epsilon = 1e-6);
+            assert_abs_diff_eq!(complex.im, *imag, epsilon = 1e-6);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@
 //!
 //! - **[`traits::Source`]**: Signal generators that produce values on demand
 //! - **[`traits::Filter`]**: Signal transformers that accept and produce values
+//! - **[`traits::MultirateFilter`]**: Signal transformers with independent
+//!   input and output rates
 //! - **[`traits::Sink`]**: Signal consumers that process values
 //! - **[`traits::Finalize`]**: Extractors that compute final results from sinks
 //!
@@ -20,7 +22,7 @@
 //! use signalo::filters::fir::mean::Mean;
 //! use signalo::sources::constant::Constant;
 //! use signalo::sinks::mean::Mean as MeanSink;
-//! use signalo::traits::{Source, Filter, Sink, Finalize};
+//! use signalo::traits::{Filter, Finalize, Sink, Source};
 //!
 //! // Create a constant source generating 1.0
 //! let source = Constant::new(1.0);
@@ -83,4 +85,4 @@ pub mod sources;
 pub mod sinks;
 
 // Re-export core traits at crate root for convenience
-pub use self::traits::{Filter, Finalize, Sink, Source};
+pub use self::traits::{Filter, Finalize, MultirateFilter, Sink, Source};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,13 @@ extern crate std;
 #[cfg(any(test, feature = "alloc"))]
 extern crate alloc;
 
+#[cfg(feature = "complex")]
+pub mod complex {
+    //! Complex number types for DSP pipelines.
+
+    pub use num_complex::{Complex, Complex32, Complex64};
+}
+
 pub mod math;
 
 pub mod storage;

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -4,8 +4,9 @@
 
 //! Core trait definitions for the signal processing framework.
 //!
-//! Defines the fundamental traits: [`Source`], [`Filter`], [`Sink`],
-//! [`Finalize`], and auxiliary traits for configuration, state, and reset operations.
+//! Defines the fundamental traits: [`Source`], [`Filter`],
+//! [`MultirateFilter`], [`Sink`], [`Finalize`], and auxiliary traits for
+//! configuration, state, and reset operations.
 
 pub use guts;
 
@@ -13,12 +14,15 @@ pub mod filter;
 
 pub mod finalize;
 
+pub mod multirate_filter;
+
 pub mod sink;
 
 pub mod source;
 
 pub use self::filter::Filter;
 pub use self::finalize::Finalize;
+pub use self::multirate_filter::MultirateFilter;
 pub use self::sink::Sink;
 pub use self::source::Source;
 

--- a/src/traits/multirate_filter.rs
+++ b/src/traits/multirate_filter.rs
@@ -1,0 +1,34 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Rate-changing signal transformers with independent input and output progress.
+//!
+//! Multirate filters are the slice-based counterpart to
+//! [`Filter`](super::Filter). They support systems where the number of output
+//! samples is not necessarily equal to the number of input samples.
+
+/// Filters that consume and produce variable numbers of samples.
+///
+/// The result of concatenating all produced output data is the same as the
+/// result of applying the filter over the concatenation of the input data.
+///
+/// `process` accepts arbitrary input and output slice sizes. Implementations
+/// return `(input_consumed, output_produced)`, where `input_consumed` is less
+/// than or equal to `input.len()` and `output_produced` is less than or equal to
+/// `output.len()`.
+///
+/// If the output slice fills before all input can be consumed, callers can pass
+/// the unconsumed input to the next call. If input is exhausted before the next
+/// output is available, callers can continue later with more input. If an output
+/// becomes available when no output space remains, implementations must retain
+/// it internally and produce it on a later call rather than dropping it.
+pub trait MultirateFilter<Input>: Sized {
+    /// The filter's output sample type.
+    type Output;
+
+    /// Processes input samples into output samples.
+    ///
+    /// Returns `(input_consumed, output_produced)`.
+    fn process(&mut self, input: &[Input], output: &mut [Self::Output]) -> (usize, usize);
+}


### PR DESCRIPTION
Implemented Polyphase multirate primitives:
1. `PolyphaseFilterBank`
   stateless phase-major coefficient bank, metadata, coefficient slices, and selected-phase execution against caller-provided history

2. `PolyphaseFir`
   one delay line, `push(sample)`, and `execute(phase)` delegating to the bank.

3. `PolyphaseInterpolator`
   one input sample produces all phases.

4. `PolyphaseDecimator`
   per-phase delay lines; when a decimation cycle completes, it sums `bank.execute(phase, taps[phase])` across phases.

5. `RationalResampler`
   streaming phase accumulator and arbitrary-buffer processing.

Includes #168 and #169.
Implements #167.