### PR TITLE
Add FIR window buffer fillers

### DIFF
--- a/src/filters/fir/window.rs
+++ b/src/filters/fir/window.rs
@@ -34,6 +34,20 @@ pub mod kaiser;
 pub mod rectangular;
 pub mod triangular;
 
+#[cfg(any(feature = "libm", feature = "std"))]
+fn fill<T>(weights: &mut [T], window: impl Fn(usize, usize) -> T) {
+    let n = weights.len();
+    weights
+        .iter_mut()
+        .enumerate()
+        .for_each(|(k, weight)| *weight = window(k, n));
+}
+
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+fn to_vec<T>(num_taps: usize, window: impl Fn(usize, usize) -> T) -> alloc::vec::Vec<T> {
+    (0..num_taps).map(|k| window(k, num_taps)).collect()
+}
+
 /// Generate shared behavior tests for window types.
 ///
 /// `$with_config` — expression creating the window for `N=8` (used in

--- a/src/filters/fir/window/blackman.rs
+++ b/src/filters/fir/window/blackman.rs
@@ -38,6 +38,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with Blackman window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::blackman);
+}
+
+/// Create heap-backed Blackman window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::blackman)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -55,12 +68,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::blackman;
         assert!(N > 0, "Blackman: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = blackman::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }

--- a/src/filters/fir/window/blackman_harris.rs
+++ b/src/filters/fir/window/blackman_harris.rs
@@ -35,6 +35,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with Blackman-Harris window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::blackman_harris);
+}
+
+/// Create heap-backed Blackman-Harris window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::blackman_harris)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -52,12 +65,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::blackman_harris;
         assert!(N > 0, "BlackmanHarris: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = blackman_harris::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }

--- a/src/filters/fir/window/flat_top.rs
+++ b/src/filters/fir/window/flat_top.rs
@@ -44,6 +44,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with flat-top window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::flat_top);
+}
+
+/// Create heap-backed flat-top window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::flat_top)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -60,12 +73,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::flat_top;
         assert!(N > 0, "FlatTop: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = flat_top::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }

--- a/src/filters/fir/window/hamming.rs
+++ b/src/filters/fir/window/hamming.rs
@@ -37,6 +37,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with Hamming window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::hamming);
+}
+
+/// Create heap-backed Hamming window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::hamming)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -53,12 +66,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::hamming;
         assert!(N > 0, "Hamming: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = hamming::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }

--- a/src/filters/fir/window/hann.rs
+++ b/src/filters/fir/window/hann.rs
@@ -35,6 +35,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with Hann window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::hann);
+}
+
+/// Create heap-backed Hann window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::hann)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -51,12 +64,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::hann;
         assert!(N > 0, "Hann: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = hann::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }

--- a/src/filters/fir/window/kaiser.rs
+++ b/src/filters/fir/window/kaiser.rs
@@ -17,9 +17,6 @@ use crate::traits::{
 #[cfg(feature = "derive")]
 use crate::traits::ResetMut;
 
-#[cfg(any(feature = "libm", feature = "std"))]
-pub(crate) use crate::math::bessel_i0;
-
 /// The Kaiser window's configuration with precomputed weights and beta parameter.
 ///
 /// `C` is the storage container for the precomputed window weights and must
@@ -42,6 +39,36 @@ pub struct Config<T, C> {
     pub weights: C,
 }
 
+/// Fill a slice with Kaiser window weights.
+///
+/// # Panics
+///
+/// Panics if β is negative or NaN and `weights` is not empty.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: Float + core::fmt::Debug>(weights: &mut [T], beta: T) {
+    if weights.is_empty() {
+        return;
+    }
+    assert!(beta >= T::zero(), "Kaiser beta must be non-negative");
+    super::fill(weights, crate::filters::util::window::kaiser(beta));
+}
+
+/// Create heap-backed Kaiser window weights.
+///
+/// # Panics
+///
+/// Panics if β is negative or NaN and `num_taps` is not zero.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: Float + core::fmt::Debug>(num_taps: usize, beta: T) -> alloc::vec::Vec<T> {
+    if num_taps == 0 {
+        return alloc::vec::Vec::new();
+    }
+    assert!(beta >= T::zero(), "Kaiser beta must be non-negative");
+    let window = crate::filters::util::window::kaiser(beta);
+    super::to_vec(num_taps, window)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(clippy::unwrap_used, clippy::missing_panics_doc)]
 impl<T: Float + core::fmt::Debug, const N: usize> Config<T, [T; N]> {
@@ -60,23 +87,9 @@ impl<T: Float + core::fmt::Debug, const N: usize> Config<T, [T; N]> {
     /// Panics if β is negative or NaN, or if N is 0.
     #[must_use]
     pub fn new(beta: T) -> Self {
-        assert!(beta >= T::zero(), "Kaiser beta must be non-negative");
         assert!(N > 0, "Kaiser: window size N must be > 0");
-        let one = T::one();
         let mut weights = [T::zero(); N];
-        if N == 1 {
-            weights[0] = one;
-            return Self { beta, weights };
-        }
-        let i0_beta = bessel_i0(beta);
-        let n_minus_1 = T::from(N - 1).unwrap();
-        let two = T::from(2.0).unwrap();
-        for (k, weight) in weights.iter_mut().enumerate() {
-            let k_f = T::from(k).unwrap();
-            let arg = two * k_f / n_minus_1 - one;
-            let root = (one - arg * arg).max(T::zero()).sqrt();
-            *weight = bessel_i0(beta * root) / i0_beta;
-        }
+        window(&mut weights, beta);
         Self { beta, weights }
     }
 

--- a/src/filters/fir/window/kaiser/tests.rs
+++ b/src/filters/fir/window/kaiser/tests.rs
@@ -6,6 +6,9 @@ use std::vec::Vec;
 
 use approx::assert_abs_diff_eq;
 
+#[cfg(any(feature = "libm", feature = "std"))]
+use crate::math::bessel_i0;
+
 use super::*;
 
 fn numeric_fixture() -> Vec<f32> {

--- a/src/filters/fir/window/rectangular.rs
+++ b/src/filters/fir/window/rectangular.rs
@@ -23,6 +23,18 @@ use crate::traits::ResetMut;
 #[derive(Clone, Debug)]
 pub struct Config<T, const N: usize>(PhantomData<T>);
 
+/// Fill a slice with rectangular window weights.
+pub fn window<T: One>(weights: &mut [T]) {
+    weights.fill_with(T::one);
+}
+
+/// Create heap-backed rectangular window weights.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn window_vec<T: One>(num_taps: usize) -> alloc::vec::Vec<T> {
+    core::iter::repeat_with(T::one).take(num_taps).collect()
+}
+
 /// The rectangular window's state (unit struct — no runtime tracking needed).
 #[derive(Clone, Debug, Default)]
 pub struct State;

--- a/src/filters/fir/window/triangular.rs
+++ b/src/filters/fir/window/triangular.rs
@@ -35,6 +35,19 @@ pub struct Config<C> {
     pub weights: C,
 }
 
+/// Fill a slice with triangular window weights.
+#[cfg(any(feature = "libm", feature = "std"))]
+pub fn window<T: num_traits::Float>(weights: &mut [T]) {
+    super::fill(weights, crate::filters::util::window::triangular);
+}
+
+/// Create heap-backed triangular window weights.
+#[cfg(all(feature = "alloc", any(feature = "libm", feature = "std")))]
+#[must_use]
+pub fn window_vec<T: num_traits::Float>(num_taps: usize) -> alloc::vec::Vec<T> {
+    super::to_vec(num_taps, crate::filters::util::window::triangular)
+}
+
 #[cfg(any(feature = "libm", feature = "std"))]
 #[allow(
     clippy::new_without_default,
@@ -51,12 +64,9 @@ impl<T: num_traits::Float, const N: usize> Config<[T; N]> {
     /// Panics if `N == 0`.
     #[must_use]
     pub fn new() -> Self {
-        use crate::filters::util::window::triangular;
         assert!(N > 0, "Triangular: window size N must be > 0");
         let mut weights = [T::zero(); N];
-        for (k, w) in weights.iter_mut().enumerate() {
-            *w = triangular::<T>(k, N);
-        }
+        window(&mut weights);
         Self { weights }
     }
 }


### PR DESCRIPTION
Expose in-place window weight fillers and `alloc`-backed Vec constructors for FIR window modules.

Route existing array `Config` constructors through the new fillers while reusing the existing private point kernels for each window formula.

This is a first step toward the buffer-first window design discussed in #173.