### PR TITLE
Add FIR pulse-shaping tap designers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ Please make sure to add your changes to the appropriate categories:
 - Added "complex" feature (opt-in `dep:num-complex`) for `Complex<T>` IQ sample support
 - Made `Convolve` generic over coefficient type `K` to support complex input with real taps (fixes #166)
 - Added `crate::math::phase` module with 32-bit wrapping phase-word trigonometry: `sin`, `cos`, `sin_cos`, and `phasor` (behind `complex` feature)
+- Added `fir::design` module with raised-cosine, root-raised-cosine, and GMSK Gaussian pulse-tap generators
+- Added `Normalization` tap-normalization enum (`None`, `UnitEnergy`, `UnitPeak`, `PassbandGain`)
+- Added `Erf` trait and `erf()` free function (behind `libm` feature)
+- Added `math::bessel_i0` for modified Bessel function of the first kind, order 0
+- Added `math::safe_normalise_divisor` for validated denominator guarding
 
 ### Changed
 

--- a/src/filters/fir.rs
+++ b/src/filters/fir.rs
@@ -42,6 +42,7 @@
 
 pub mod comb;
 pub mod convolve;
+pub mod design;
 pub mod differentiate;
 pub mod mean;
 pub mod mean_variance;

--- a/src/filters/fir/design.rs
+++ b/src/filters/fir/design.rs
@@ -1,0 +1,153 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! FIR coefficient design helpers.
+//!
+//! This module contains functions that generate FIR taps for pulse shaping.
+//! Unlike windows, pulse shapes are specified in symbol-time parameters such as
+//! span and samples per symbol; the allocated helpers derive the tap count as
+//! `span * sps + 1`.
+//!
+//! Here `span` is the full pulse length in symbols, not the per-side delay.
+//! The generated time grid runs from `-span / 2` to `+span / 2` symbols,
+//! sampled at `sps` samples per symbol, so the FIR has `span * sps + 1` taps.
+//! This full-span convention matches what many SDR libraries use. Some APIs
+//! instead use a per-side symbol delay and compute the length as
+//! `2 * sps * delay + 1`; for those APIs, use `span = 2 * delay` here. APIs
+//! that take `ntaps` directly do not expose this span/half-span distinction.
+//!
+//! Pulse-shaping helpers generate an odd number of taps. This keeps the pulse
+//! centered on an actual tap and gives the symmetric FIR an integer group
+//! delay, which is the usual linear-phase layout for these filters.
+//!
+//! Each pulse shape provides `taps` with a default normalization and
+//! `taps_with_norm` for choosing a [`Normalization`] explicitly. With `alloc`,
+//! the matching vector-returning helpers are `taps_vec` and
+//! `taps_with_norm_vec`.
+//!
+//! Default normalizations:
+//!
+//! - Raised cosine: [`Normalization::UnitEnergy`].
+//! - Square-root raised cosine: [`Normalization::UnitEnergy`].
+//! - GMSK Gaussian pulse: [`Normalization::PassbandGain`].
+//!
+//! # Feature flags
+//!
+//! Raised-cosine and square-root raised-cosine design require either `std` or
+//! `libm`. GMSK Gaussian pulse design requires `libm` for error-function
+//! support.
+
+#[cfg(any(feature = "libm", feature = "std"))]
+use num_traits::Float;
+
+#[cfg(feature = "libm")]
+pub mod gaussian_pulse;
+#[cfg(any(feature = "libm", feature = "std"))]
+pub mod raised_cosine;
+#[cfg(any(feature = "libm", feature = "std"))]
+pub mod root_raised_cosine;
+
+/// Filter-design tap normalization mode.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum Normalization {
+    /// Leave taps as computed.
+    None,
+    /// Scale taps so `sum(abs(h[k])^2) == 1`.
+    #[default]
+    UnitEnergy,
+    /// Scale taps so `max(abs(h[k])) == 1`.
+    UnitPeak,
+    /// Scale taps so `sum(h[k]) == 1`.
+    PassbandGain,
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+/// Return the odd tap count for a pulse with full-symbol `span` and samples per
+/// symbol `sps`.
+///
+/// The length is `span * sps + 1`. `span * sps` must be even so the resulting
+/// impulse response has odd length and can be centered on one tap.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps`
+/// overflows, or `span * sps + 1` overflows.
+pub(crate) const fn len_from_span(span: usize, sps: usize) -> usize {
+    assert!(span > 0, "span must be > 0");
+    assert!(sps >= 2, "samples per symbol must be >= 2");
+    let samples = span.checked_mul(sps).expect("span * sps overflowed");
+    assert!(
+        samples.is_multiple_of(2),
+        "span * sps must be even for a symmetric pulse"
+    );
+    samples.checked_add(1).expect("tap count overflowed")
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+/// Apply the requested normalization to generated taps in place.
+///
+/// `Normalization::None` leaves the taps unchanged. Other modes scale all taps
+/// by a single gain factor computed from the current slice contents.
+///
+/// # Panics
+///
+/// Panics if the required normalization divisor is not finite or is too small
+/// for safe division.
+pub(crate) fn normalize<T>(taps: &mut [T], mode: Normalization)
+where
+    T: Float + core::fmt::Debug,
+{
+    match mode {
+        Normalization::None => {}
+        Normalization::UnitEnergy => normalize_unit_energy(taps),
+        Normalization::UnitPeak => normalize_unit_peak(taps),
+        Normalization::PassbandGain => normalize_passband_gain(taps),
+    }
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+fn normalize_unit_energy<T>(taps: &mut [T])
+where
+    T: Float + core::fmt::Debug,
+{
+    let sum = taps.iter().fold(T::zero(), |sum, tap| sum + (*tap * *tap));
+    if !sum.is_zero() {
+        let denom = crate::math::safe_normalise_divisor(sum.sqrt(), "unit-energy normalization");
+        let gain = T::one() / denom;
+        for tap in taps {
+            *tap = *tap * gain;
+        }
+    }
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+fn normalize_unit_peak<T>(taps: &mut [T])
+where
+    T: Float + core::fmt::Debug,
+{
+    let max = taps.iter().fold(T::zero(), |max, tap| max.max(tap.abs()));
+    if !max.is_zero() {
+        let denom = crate::math::safe_normalise_divisor(max, "unit-peak normalization");
+        let gain = T::one() / denom;
+        for tap in taps {
+            *tap = *tap * gain;
+        }
+    }
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+fn normalize_passband_gain<T>(taps: &mut [T])
+where
+    T: Float + core::fmt::Debug,
+{
+    let sum = taps.iter().fold(T::zero(), |sum, tap| sum + *tap);
+    if !sum.is_zero() {
+        let denom = crate::math::safe_normalise_divisor(sum, "passband-gain normalization");
+        let gain = T::one() / denom;
+        for tap in taps {
+            *tap = *tap * gain;
+        }
+    }
+}

--- a/src/filters/fir/design/gaussian_pulse.rs
+++ b/src/filters/fir/design/gaussian_pulse.rs
@@ -1,0 +1,122 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Gaussian frequency pulse taps for GMSK.
+
+use num_traits::Float;
+
+use super::{len_from_span, normalize, Normalization};
+use crate::math::{erf, Erf};
+
+/// Fill a slice with GMSK Gaussian frequency pulse taps and explicit normalization.
+///
+/// This is the BT-parameterized integrated Gaussian pulse used by GMSK
+/// modulators, not a Gaussian window. `span` is the full pulse length in
+/// symbols, not the per-side delay. The tap count must be `span * sps + 1`,
+/// and `weights.len()` must match that value.
+///
+/// `sps` is the number of samples per symbol. `bt` is the bandwidth-time
+/// product. `norm` selects the final tap normalization.
+/// Typical GMSK deployments use `bt` in the range `[0.3, 0.5]`; values below
+/// roughly `0.2` require a correspondingly larger `span` to avoid significant
+/// truncation error.
+///
+/// # Panics
+///
+/// Panics if `bt <= 0`, `span == 0`, `sps < 2`, `span * sps` is odd,
+/// `span * sps + 1` overflows, or the tap count is not `span * sps + 1`.
+pub fn taps_with_norm<T>(weights: &mut [T], span: usize, sps: usize, bt: T, norm: Normalization)
+where
+    T: Float + Erf + core::fmt::Debug,
+{
+    let len = len_from_span(span, sps);
+    assert_eq!(
+        weights.len(),
+        len,
+        "gaussian_pulse: tap count must equal span * sps + 1"
+    );
+    let samples = len - 1;
+
+    assert!(bt > T::zero(), "gaussian_pulse: BT must be > 0");
+
+    let pi = T::from(core::f64::consts::PI).expect("π is representable");
+    let sqrt_2 = T::from(core::f64::consts::SQRT_2).expect("sqrt(2) is representable");
+    let sps_t = T::from(sps).expect("sps is representable");
+    let two = T::from(2.0).expect("2 is representable");
+    let half_scalar = T::from(0.5).expect("0.5 is representable");
+    let sigma = T::ln(two).sqrt() / (two * pi * bt);
+    let inv = T::one() / (sqrt_2 * sigma * sps_t);
+    let half = sps_t * half_scalar;
+    let Ok(center) = isize::try_from(samples / 2) else {
+        panic!("gaussian_pulse: tap count must fit in isize");
+    };
+
+    for (index, weight) in weights.iter_mut().enumerate() {
+        let Ok(index) = isize::try_from(index) else {
+            panic!("gaussian_pulse: tap index must fit in isize");
+        };
+        let n = index - center;
+        let t = T::from(n).expect("tap index is representable");
+        *weight = half_scalar * (erf((t + half) * inv) - erf((t - half) * inv));
+    }
+
+    normalize(weights, norm);
+}
+
+/// Fill a slice with GMSK Gaussian frequency pulse taps.
+///
+/// Taps are passband-gain normalized. See [`taps_with_norm`] for the details.
+pub fn taps<T>(weights: &mut [T], span: usize, sps: usize, bt: T)
+where
+    T: Float + Erf + core::fmt::Debug,
+{
+    taps_with_norm(weights, span, sps, bt, Normalization::PassbandGain);
+}
+
+/// Create heap-backed GMSK Gaussian frequency pulse taps with explicit normalization.
+///
+/// `span` is the full pulse length in symbols, not the per-side delay. The
+/// returned vector has `span * sps + 1` taps. `span * sps` must be even so the
+/// result has odd length and is centered on one tap.
+///
+/// This is the allocating equivalent of [`taps_with_norm`]. `sps` is the number
+/// of samples per symbol, `bt` is the bandwidth-time product, and `norm` selects
+/// the final tap normalization. See [`taps_with_norm`] for practical `bt`
+/// range guidance.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps + 1`
+/// overflows, or `bt <= 0`.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_with_norm_vec<T>(
+    span: usize,
+    sps: usize,
+    bt: T,
+    norm: Normalization,
+) -> alloc::vec::Vec<T>
+where
+    T: Float + Erf + core::fmt::Debug,
+{
+    let len = super::len_from_span(span, sps);
+    let mut weights = alloc::vec![T::zero(); len];
+    taps_with_norm(&mut weights, span, sps, bt, norm);
+    weights
+}
+
+/// Create heap-backed GMSK Gaussian frequency pulse taps.
+///
+/// Taps are passband-gain normalized. See [`taps_with_norm_vec`] for the details.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_vec<T>(span: usize, sps: usize, bt: T) -> alloc::vec::Vec<T>
+where
+    T: Float + Erf + core::fmt::Debug,
+{
+    taps_with_norm_vec(span, sps, bt, Normalization::PassbandGain)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/filters/fir/design/gaussian_pulse/tests.rs
+++ b/src/filters/fir/design/gaussian_pulse/tests.rs
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use approx::assert_abs_diff_eq;
+
+use super::{taps, taps_with_norm};
+use crate::filters::fir::design::{len_from_span, Normalization};
+
+#[test]
+#[allow(clippy::excessive_precision, clippy::unreadable_literal)]
+fn taps_match_reference() {
+    const LEN: usize = len_from_span(4, 4);
+    let expected = [
+        7.438_679_225_487_701e-7,
+        2.012_670_875_194_407e-5,
+        3.1727481185161663e-4,
+        2.9462688262236955e-3,
+        1.6399631027448684e-2,
+        5.628_444_112_335_107e-2,
+        1.2468272901724888e-1,
+        1.9074915548782734e-1,
+        2.1719925825874842e-1,
+        1.9074915548782734e-1,
+        1.2468272901724888e-1,
+        5.628_444_112_335_107e-2,
+        1.6399631027448684e-2,
+        2.9462688262236955e-3,
+        3.1727481185161663e-4,
+        2.012_670_875_194_407e-5,
+        7.438_679_225_487_701e-7,
+    ];
+
+    let mut actual = [0.0; LEN];
+    taps(&mut actual, 4, 4, 0.4);
+
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        assert_abs_diff_eq!(actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn in_place_matches_vec() {
+    const LEN: usize = len_from_span(6, 8);
+    let expected = super::taps_vec(6, 8, 0.4_f64);
+    let mut actual = [0.0; LEN];
+
+    taps(&mut actual, 6, 8, 0.4);
+
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert_abs_diff_eq!(*actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[test]
+fn passband_gain_normalizes_sum_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    super::taps(&mut taps, 6, 8, 0.4);
+    let sum = taps.into_iter().sum::<f64>();
+
+    assert_abs_diff_eq!(sum, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+fn explicit_unit_energy_normalizes_energy_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    taps_with_norm(&mut taps, 6, 8, 0.4, Normalization::UnitEnergy);
+    let energy = taps.into_iter().map(|tap| tap * tap).sum::<f64>().sqrt();
+
+    assert_abs_diff_eq!(energy, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+#[should_panic(expected = "tap count must equal span * sps + 1")]
+fn incompatible_length_panics() {
+    let mut taps = [0.0; 16];
+    super::taps(&mut taps, 4, 4, 0.4);
+}

--- a/src/filters/fir/design/raised_cosine.rs
+++ b/src/filters/fir/design/raised_cosine.rs
@@ -1,0 +1,137 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Raised-cosine pulse-shaping taps.
+
+use num_traits::Float;
+
+use super::{len_from_span, normalize, Normalization};
+
+/// Fill a slice with raised-cosine pulse-shaping taps and explicit normalization.
+///
+/// `span` is the full pulse length in symbols, not the per-side delay. The tap
+/// count must be `span * sps + 1`, and `weights.len()` must match that value.
+///
+/// `sps` is the number of samples per symbol. `rolloff` is the excess bandwidth
+/// factor in `[0, 1]`. `norm` selects the final tap normalization.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps + 1`
+/// overflows, the tap count is not `span * sps + 1`, or `rolloff` is outside
+/// `[0, 1]`.
+pub fn taps_with_norm<T>(
+    weights: &mut [T],
+    span: usize,
+    sps: usize,
+    rolloff: T,
+    norm: Normalization,
+) where
+    T: Float + core::fmt::Debug,
+{
+    let len = len_from_span(span, sps);
+    assert_eq!(
+        weights.len(),
+        len,
+        "raised_cosine: tap count must equal span * sps + 1"
+    );
+    let samples = len - 1;
+
+    assert!(
+        rolloff >= T::zero() && rolloff <= T::one(),
+        "raised_cosine: rolloff must be in [0, 1]"
+    );
+
+    let pi = T::from(core::f64::consts::PI).expect("π is representable");
+    let sps_t = T::from(sps).expect("sps is representable");
+    let two = T::from(2.0).expect("2 is representable");
+    let four = T::from(4.0).expect("4 is representable");
+    let inv_sps = T::one() / sps_t;
+    let Ok(half) = isize::try_from(samples / 2) else {
+        panic!("raised_cosine: tap count must fit in isize");
+    };
+
+    for (index, weight) in weights.iter_mut().enumerate() {
+        let Ok(index) = isize::try_from(index) else {
+            panic!("raised_cosine: tap index must fit in isize");
+        };
+        let n = index - half;
+        let tap = if n == 0 {
+            T::one()
+        } else {
+            let n_t = T::from(n).expect("tap index is representable");
+            let x = n_t * inv_sps;
+            let two_rolloff_x = two * rolloff * x;
+            let denom = T::one() - two_rolloff_x * two_rolloff_x;
+
+            if rolloff > T::zero() && denom.abs() <= T::epsilon() * four {
+                (rolloff / two) * (pi / (two * rolloff)).sin()
+            } else {
+                let sinc = (pi * x).sin() / (pi * x);
+                let rolloff_term = (pi * rolloff * x).cos() / denom;
+                sinc * rolloff_term
+            }
+        };
+
+        *weight = tap;
+    }
+
+    normalize(weights, norm);
+}
+
+/// Fill a slice with raised-cosine pulse-shaping taps.
+///
+/// Taps are unit-energy normalized. See [`taps_with_norm`] for the details.
+pub fn taps<T>(weights: &mut [T], span: usize, sps: usize, rolloff: T)
+where
+    T: Float + core::fmt::Debug,
+{
+    taps_with_norm(weights, span, sps, rolloff, Normalization::UnitEnergy);
+}
+
+/// Create heap-backed raised-cosine pulse-shaping taps with explicit normalization.
+///
+/// `span` is the full pulse length in symbols, not the per-side delay. The
+/// returned vector has `span * sps + 1` taps. `span * sps` must be even so the
+/// result has odd length and is centered on one tap.
+///
+/// This is the allocating equivalent of [`taps_with_norm`]. `sps` is the number
+/// samples per symbol, `rolloff` is the excess bandwidth factor in `[0, 1]`,
+/// and `norm` selects the final tap normalization.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps + 1`
+/// overflows, or `rolloff` is outside `[0, 1]`.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_with_norm_vec<T>(
+    span: usize,
+    sps: usize,
+    rolloff: T,
+    norm: Normalization,
+) -> alloc::vec::Vec<T>
+where
+    T: Float + core::fmt::Debug,
+{
+    let len = super::len_from_span(span, sps);
+    let mut weights = alloc::vec![T::zero(); len];
+    taps_with_norm(&mut weights, span, sps, rolloff, norm);
+    weights
+}
+
+/// Create heap-backed raised-cosine pulse-shaping taps.
+///
+/// Taps are unit-energy normalized. See [`taps_with_norm_vec`] for the details.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_vec<T>(span: usize, sps: usize, rolloff: T) -> alloc::vec::Vec<T>
+where
+    T: Float + core::fmt::Debug,
+{
+    taps_with_norm_vec(span, sps, rolloff, Normalization::UnitEnergy)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/filters/fir/design/raised_cosine/tests.rs
+++ b/src/filters/fir/design/raised_cosine/tests.rs
@@ -1,0 +1,95 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use approx::assert_abs_diff_eq;
+
+use super::taps;
+use crate::filters::fir::design::{len_from_span, raised_cosine, Normalization};
+
+#[test]
+#[allow(clippy::unreadable_literal)]
+fn taps_match_reference() {
+    const LEN: usize = len_from_span(4, 4);
+    let expected = [
+        -1.2518515017362982e-17,
+        -4.6639290287991825e-2,
+        -8.519_668_263_130_235e-2,
+        -7.861_292_223_060_691e-2,
+        1.820_044_267_668_487e-17,
+        1.475_017_275_341_517e-1,
+        3.244_465_555_013_721e-1,
+        4.6884385557492e-1,
+        5.244_986_604_669_218e-1,
+        4.6884385557492e-1,
+        3.244_465_555_013_721e-1,
+        1.475_017_275_341_517e-1,
+        1.820_044_267_668_487e-17,
+        -7.861_292_223_060_691e-2,
+        -8.519_668_263_130_235e-2,
+        -4.6639290287991825e-2,
+        -1.2518515017362982e-17,
+    ];
+
+    let mut actual = [0.0; LEN];
+    taps(&mut actual, 4, 4, 0.35);
+
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        assert_abs_diff_eq!(actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn in_place_matches_vec() {
+    const LEN: usize = len_from_span(6, 8);
+    let expected = super::taps_with_norm_vec(6, 8, 0.25_f64, Normalization::PassbandGain);
+    let mut actual = [0.0; LEN];
+
+    super::taps_with_norm(&mut actual, 6, 8, 0.25, Normalization::PassbandGain);
+
+    assert_eq!(actual.as_slice(), expected.as_slice());
+}
+
+#[test]
+fn unit_energy_normalizes_energy_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    super::taps(&mut taps, 6, 8, 0.35);
+    let energy = taps.into_iter().map(|tap| tap * tap).sum::<f64>().sqrt();
+
+    assert_abs_diff_eq!(energy, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+fn passband_gain_normalizes_sum_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    super::taps_with_norm(&mut taps, 6, 8, 0.35, Normalization::PassbandGain);
+    let sum = taps.into_iter().sum::<f64>();
+
+    assert_abs_diff_eq!(sum, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+fn zero_isi_at_symbol_instants() {
+    const SPAN: usize = 6;
+    const SPS: usize = 8;
+    const LEN: usize = len_from_span(SPAN, SPS);
+    let mut taps = [0.0; LEN];
+    let center = (LEN - 1) / 2;
+
+    raised_cosine::taps_with_norm(&mut taps, SPAN, SPS, 0.35, Normalization::None);
+
+    for symbol in 1..=(SPAN / 2) {
+        assert_abs_diff_eq!(taps[center + symbol * SPS], 0.0, epsilon = 1e-10);
+        assert_abs_diff_eq!(taps[center - symbol * SPS], 0.0, epsilon = 1e-10);
+    }
+}
+
+#[test]
+#[should_panic(expected = "tap count must equal span * sps + 1")]
+fn incompatible_length_panics() {
+    let mut taps = [0.0; 16];
+    super::taps(&mut taps, 4, 4, 0.35);
+}

--- a/src/filters/fir/design/root_raised_cosine.rs
+++ b/src/filters/fir/design/root_raised_cosine.rs
@@ -1,0 +1,144 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Square-root raised-cosine pulse-shaping taps.
+
+use num_traits::Float;
+
+use super::{len_from_span, normalize, Normalization};
+
+/// Fill a slice with square-root raised-cosine taps and explicit normalization.
+///
+/// `span` is the full pulse length in symbols, not the per-side delay. The tap
+/// count must be `span * sps + 1`, and `weights.len()` must match that value.
+///
+/// `sps` is the number of samples per symbol. `rolloff` is the excess bandwidth
+/// factor in `[0, 1]`. `norm` selects the final tap normalization.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps + 1`
+/// overflows, the tap count is not `span * sps + 1`, or `rolloff` is outside
+/// `[0, 1]`.
+pub fn taps_with_norm<T>(
+    weights: &mut [T],
+    span: usize,
+    sps: usize,
+    rolloff: T,
+    norm: Normalization,
+) where
+    T: Float + core::fmt::Debug,
+{
+    let len = len_from_span(span, sps);
+    assert_eq!(
+        weights.len(),
+        len,
+        "root_raised_cosine: tap count must equal span * sps + 1"
+    );
+    let samples = len - 1;
+
+    assert!(
+        rolloff >= T::zero() && rolloff <= T::one(),
+        "root_raised_cosine: rolloff must be in [0, 1]"
+    );
+
+    let pi = T::from(core::f64::consts::PI).expect("π is representable");
+    let sps_t = T::from(sps).expect("sps is representable");
+    let sqrt_2 = T::from(core::f64::consts::SQRT_2).expect("sqrt(2) is representable");
+    let two = T::from(2.0).expect("2 is representable");
+    let four = T::from(4.0).expect("4 is representable");
+    let inv_sps = T::one() / sps_t;
+    let sqrt_sps = sps_t.sqrt();
+    let Ok(half) = isize::try_from(samples / 2) else {
+        panic!("root_raised_cosine: tap count must fit in isize");
+    };
+
+    for (index, weight) in weights.iter_mut().enumerate() {
+        let Ok(index) = isize::try_from(index) else {
+            panic!("root_raised_cosine: tap index must fit in isize");
+        };
+        let offset = index - half;
+        let offset_t = T::from(offset).expect("tap index is representable");
+        let symbol_time = offset_t * inv_sps;
+        let four_rolloff_time = four * rolloff * symbol_time;
+
+        let tap = if symbol_time == T::zero() {
+            (T::one() - rolloff + four * rolloff / pi) * sqrt_sps
+        } else {
+            let quad_denominator = T::one() - four_rolloff_time * four_rolloff_time;
+            if rolloff > T::zero() && quad_denominator.abs() <= T::epsilon() * four {
+                let s = (pi / (four * rolloff)).sin();
+                let c = (pi / (four * rolloff)).cos();
+                let g1 = T::one() + two / pi;
+                let g3 = T::one() - two / pi;
+                (rolloff / sqrt_2) * (g1 * s + g3 * c) * sqrt_sps
+            } else {
+                let low_side = (pi * (T::one() - rolloff) * symbol_time).sin();
+                let high_side = four_rolloff_time * (pi * (T::one() + rolloff) * symbol_time).cos();
+                let denominator = (pi * symbol_time) * quad_denominator;
+                ((low_side + high_side) / denominator) * sqrt_sps
+            }
+        };
+
+        *weight = tap;
+    }
+
+    normalize(weights, norm);
+}
+
+/// Fill a slice with square-root raised-cosine pulse-shaping taps.
+///
+/// Taps are unit-energy normalized. See [`taps_with_norm`] for the details.
+pub fn taps<T>(weights: &mut [T], span: usize, sps: usize, rolloff: T)
+where
+    T: Float + core::fmt::Debug,
+{
+    taps_with_norm(weights, span, sps, rolloff, Normalization::UnitEnergy);
+}
+
+/// Create heap-backed square-root raised-cosine taps with explicit normalization.
+///
+/// `span` is the full pulse length in symbols, not the per-side delay. The
+/// returned vector has `span * sps + 1` taps. `span * sps` must be even so the
+/// result has odd length and is centered on one tap.
+///
+/// This is the allocating equivalent of [`taps_with_norm`]. `sps` is the number
+/// samples per symbol, `rolloff` is the excess bandwidth factor in `[0, 1]`,
+/// and `norm` selects the final tap normalization.
+///
+/// # Panics
+///
+/// Panics if `span == 0`, `sps < 2`, `span * sps` is odd, `span * sps + 1`
+/// overflows, or `rolloff` is outside `[0, 1]`.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_with_norm_vec<T>(
+    span: usize,
+    sps: usize,
+    rolloff: T,
+    norm: Normalization,
+) -> alloc::vec::Vec<T>
+where
+    T: Float + core::fmt::Debug,
+{
+    let len = super::len_from_span(span, sps);
+    let mut weights = alloc::vec![T::zero(); len];
+    taps_with_norm(&mut weights, span, sps, rolloff, norm);
+    weights
+}
+
+/// Create heap-backed square-root raised-cosine pulse-shaping taps.
+///
+/// Taps are unit-energy normalized. See [`taps_with_norm_vec`] for the details.
+#[cfg(feature = "alloc")]
+#[must_use]
+pub fn taps_vec<T>(span: usize, sps: usize, rolloff: T) -> alloc::vec::Vec<T>
+where
+    T: Float + core::fmt::Debug,
+{
+    taps_with_norm_vec(span, sps, rolloff, Normalization::UnitEnergy)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/filters/fir/design/root_raised_cosine/tests.rs
+++ b/src/filters/fir/design/root_raised_cosine/tests.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+use approx::assert_abs_diff_eq;
+
+use super::taps;
+use crate::filters::fir::design::{
+    len_from_span, raised_cosine, root_raised_cosine, Normalization,
+};
+
+#[test]
+#[allow(clippy::unreadable_literal)]
+fn taps_match_reference() {
+    const LEN: usize = len_from_span(4, 4);
+    let expected = [
+        2.8607931050595666e-2,
+        -1.10549735681297e-2,
+        -6.769_630_089_467_077e-2,
+        -9.44759673964384e-2,
+        -4.241_671_436_495_778e-2,
+        1.0361045396849711e-1,
+        3.044_005_078_498_384e-1,
+        4.793_719_664_108_898e-1,
+        5.487_429_654_786_262e-1,
+        4.793_719_664_108_898e-1,
+        3.044_005_078_498_384e-1,
+        1.0361045396849711e-1,
+        -4.241_671_436_495_778e-2,
+        -9.44759673964384e-2,
+        -6.769_630_089_467_077e-2,
+        -1.10549735681297e-2,
+        2.8607931050595666e-2,
+    ];
+
+    let mut actual = [0.0; LEN];
+    taps(&mut actual, 4, 4, 0.35);
+
+    for (actual, expected) in actual.into_iter().zip(expected) {
+        assert_abs_diff_eq!(actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn in_place_matches_vec() {
+    const LEN: usize = len_from_span(6, 8);
+    let expected = super::taps_with_norm_vec(6, 8, 0.25_f64, Normalization::PassbandGain);
+    let mut actual = [0.0; LEN];
+
+    super::taps_with_norm(&mut actual, 6, 8, 0.25, Normalization::PassbandGain);
+
+    assert_eq!(actual.as_slice(), expected.as_slice());
+}
+
+#[test]
+fn unit_energy_normalizes_energy_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    super::taps(&mut taps, 6, 8, 0.35);
+    let energy = taps.into_iter().map(|tap| tap * tap).sum::<f64>().sqrt();
+
+    assert_abs_diff_eq!(energy, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+fn passband_gain_normalizes_sum_to_one() {
+    const LEN: usize = len_from_span(6, 8);
+    let mut taps = [0.0; LEN];
+    super::taps_with_norm(&mut taps, 6, 8, 0.35, Normalization::PassbandGain);
+    let sum = taps.into_iter().sum::<f64>();
+
+    assert_abs_diff_eq!(sum, 1.0, epsilon = 1e-12);
+}
+
+#[test]
+fn matched_filter_gives_raised_cosine_at_symbol_instants() {
+    const SPAN: usize = 64;
+    const SPS: usize = 8;
+    const LEN: usize = len_from_span(SPAN, SPS);
+    const CONV_LEN: usize = 2 * LEN - 1;
+    let rolloff = 0.35;
+    let mut rrc = [0.0; LEN];
+    let mut rc = [0.0; LEN];
+    let mut conv = [0.0; CONV_LEN];
+
+    root_raised_cosine::taps_with_norm(&mut rrc, SPAN, SPS, rolloff, Normalization::None);
+    raised_cosine::taps_with_norm(&mut rc, SPAN, SPS, rolloff, Normalization::None);
+
+    // Convolve the root-raised-cosine with itself to get a raised-cosine.
+    for (i, &a) in rrc.iter().enumerate() {
+        for (j, &b) in rrc.iter().enumerate() {
+            conv[i + j] += a * b;
+        }
+    }
+
+    // The central `n` samples of the convolution should match rc (up to a
+    // common scalar, since both are un-normalized).  Check only at symbol
+    // instants where ISI nulling should hold:
+    let conv_center = rrc.len() - 1;
+    let rc_center = (rc.len() - 1) / 2;
+    let scale = conv[conv_center] / rc[rc_center];
+
+    for symbol in 0..=4 {
+        assert_abs_diff_eq!(
+            conv[conv_center + symbol * SPS] / scale,
+            rc[rc_center + symbol * SPS],
+            epsilon = 1e-6
+        );
+        assert_abs_diff_eq!(
+            conv[conv_center - symbol * SPS] / scale,
+            rc[rc_center - symbol * SPS],
+            epsilon = 1e-6
+        );
+    }
+}
+
+#[test]
+#[should_panic(expected = "tap count must equal span * sps + 1")]
+fn incompatible_length_panics() {
+    let mut taps = [0.0; 16];
+    super::taps(&mut taps, 4, 4, 0.35);
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -81,6 +81,38 @@ pub fn safe_normalise_divisor<T: Float + core::fmt::Debug>(den: T, msg: &'static
     den
 }
 
+/// Error function support for floating-point types.
+#[cfg(feature = "libm")]
+pub trait Erf: Float {
+    /// Computes the error function.
+    #[must_use]
+    fn erf(self) -> Self;
+}
+
+#[cfg(feature = "libm")]
+impl Erf for f32 {
+    #[inline]
+    fn erf(self) -> Self {
+        libm::erff(self)
+    }
+}
+
+#[cfg(feature = "libm")]
+impl Erf for f64 {
+    #[inline]
+    fn erf(self) -> Self {
+        libm::erf(self)
+    }
+}
+
+/// Computes the error function.
+#[cfg(feature = "libm")]
+#[must_use]
+#[inline]
+pub fn erf<T: Erf>(x: T) -> T {
+    x.erf()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Add raised-cosine, root-raised-cosine, and GMSK Gaussian pulse tap generators under `fir::design`.

These APIs use full symbol `span` plus samples-per-symbol (`sps`).
Pulse-shaping filters are naturally specified in symbol time, and the allocated helpers derive the **odd** linear-phase tap count as:

    span * sps + 1

Default taps use common pulse-shaping normalization defaults: RC and RRC use unit energy, while Gaussian pulse uses passband gain. Explicit normalization is available through `taps_with_norm` and `taps_with_norm_vec`.

This keeps pulse/filter design separate from windows. Window helpers in SDR libraries are typically length-based and take `num_taps`, while pulse-shaping and Nyquist filter designers typically take `span` and `sps`, or an equivalent samples-per-symbol plus per-side delay.