### PR TITLE
Kahan summation helper and integrator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Please make sure to add your changes to the appropriate categories:
 ### Added
 
 - Added complex sample support to IIR biquad filters: `Biquad<T, K>` and `BiquadCascade<T, CS, SS, K>` accept an explicit coefficient type `K`, enabling `Biquad<Complex32, f32>` (requires `complex` feature)
+- Added `KahanSum<T>`, a compensated accumulator for long-running sums that repeatedly add small deltas
+- Add `KahanIntegrate<T>`, a compensated cumulative-sum filter backed by `KahanSum<T>`
 
 ### Changed
 

--- a/src/filters/iir/integrate.rs
+++ b/src/filters/iir/integrate.rs
@@ -6,6 +6,9 @@
 //!
 //! Computes the discrete integral or cumulative sum of input signals, useful for slope
 //! extraction, position tracking, and accumulation operations.
+//!
+//! [`Integrate`] is the minimal plain accumulator. [`KahanIntegrate`] uses
+//! compensated summation for long-running floating-point accumulators.
 
 use core::ops::Add;
 
@@ -18,6 +21,10 @@ use crate::traits::{
 
 #[cfg(feature = "derive")]
 use crate::traits::ResetMut;
+
+pub mod kahan;
+
+pub use kahan::KahanIntegrate;
 
 /// The integration filter's state.
 #[derive(Clone, Debug)]

--- a/src/filters/iir/integrate/kahan.rs
+++ b/src/filters/iir/integrate/kahan.rs
@@ -1,0 +1,126 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Kahan-compensated numerical integration filter.
+
+use core::ops::{Add, Sub};
+
+use num_traits::Zero;
+
+use crate::math::KahanSum;
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Filter, Reset, State as StateTrait, StateMut,
+};
+
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+
+/// An integration filter using Kahan compensated summation.
+///
+/// This variant stores an additional compensation term to reduce accumulated
+/// floating-point rounding error. It is useful for long-running floating-point
+/// integral paths whose state is updated continuously over long runtimes.
+///
+/// # Complexity
+///
+/// - **Time per sample:** O(1); several additions/subtractions.
+/// - **Space:** O(1); stores one running sum and one compensation term.
+#[derive(Clone, Debug)]
+pub struct KahanIntegrate<T> {
+    state: KahanSum<T>,
+}
+
+impl<T> Default for KahanIntegrate<T>
+where
+    T: Zero,
+{
+    fn default() -> Self {
+        Self {
+            state: KahanSum::default(),
+        }
+    }
+}
+
+impl<T> StateTrait for KahanIntegrate<T> {
+    type State = KahanSum<T>;
+}
+
+impl<T> StateMut for KahanIntegrate<T> {
+    fn state_mut(&mut self) -> &mut Self::State {
+        &mut self.state
+    }
+}
+
+impl<T> HasGuts for KahanIntegrate<T> {
+    type Guts = KahanSum<T>;
+}
+
+impl<T> FromGuts for KahanIntegrate<T> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        let state = guts;
+        Self { state }
+    }
+}
+
+impl<T> IntoGuts for KahanIntegrate<T> {
+    fn into_guts(self) -> Self::Guts {
+        self.state
+    }
+}
+
+impl<T> Reset for KahanIntegrate<T>
+where
+    T: Zero,
+{
+    fn reset(self) -> Self {
+        Self::default()
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T> ResetMut for KahanIntegrate<T> where Self: Reset {}
+
+impl<T> Filter<T> for KahanIntegrate<T>
+where
+    T: Clone + Add<T, Output = T> + Sub<T, Output = T> + Zero,
+{
+    type Output = T;
+
+    fn filter(&mut self, input: T) -> Self::Output {
+        self.state.add(input);
+        self.state.value()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::filters::iir::integrate::Integrate;
+
+    use super::*;
+
+    #[test]
+    fn kahan_integrate_matches_plain_sum_for_simple_sequence() {
+        let mut filter = KahanIntegrate::default();
+
+        assert_eq!(filter.filter(1.0_f32), 1.0);
+        assert_eq!(filter.filter(2.0), 3.0);
+        assert_eq!(filter.filter(3.0), 6.0);
+    }
+
+    #[test]
+    fn kahan_integrate_reduces_repeated_small_increment_error() {
+        let mut kahan = KahanIntegrate::<f32>::default();
+        let mut plain = Integrate::<f32>::default();
+        for _ in 0..10_000 {
+            let _ = kahan.filter(0.1_f32);
+            let _ = plain.filter(0.1);
+        }
+
+        let expected = 1_000.0_f32;
+        assert!(
+            (kahan.filter(0.0_f32) - expected).abs() < (plain.filter(0.0_f32) - expected).abs()
+        );
+    }
+}

--- a/src/math.rs
+++ b/src/math.rs
@@ -6,8 +6,97 @@
 
 pub mod phase;
 
+use core::ops::{Add, AddAssign, Sub, SubAssign};
+
+use num_traits::Zero;
+
 #[cfg(any(feature = "libm", feature = "std"))]
 use num_traits::Float;
+
+/// Kahan compensated summation accumulator.
+///
+/// Tracks a running sum plus a compensation term that estimates floating-point
+/// rounding error. This is useful for long-running accumulators that repeatedly
+/// add small deltas, such as rolling sums and numerically integrated control
+/// terms.
+///
+/// For integer types this behaves like ordinary summation until arithmetic
+/// overflow semantics apply, with additional overhead and no numerical benefit.
+/// For arbitrary numeric types, the usual Kahan error model only applies when
+/// their arithmetic behaves like rounded floating-point arithmetic.
+#[derive(Clone, Debug)]
+pub struct KahanSum<T> {
+    sum: T,
+    compensation: T,
+}
+
+impl<T> Default for KahanSum<T>
+where
+    T: Zero,
+{
+    fn default() -> Self {
+        Self {
+            sum: T::zero(),
+            compensation: T::zero(),
+        }
+    }
+}
+
+impl<T> KahanSum<T>
+where
+    T: Clone + Add<T, Output = T> + Sub<T, Output = T>,
+{
+    /// Add one value to the running sum.
+    pub fn add(&mut self, value: T) {
+        let y = value - self.compensation.clone();
+        let t = self.sum.clone() + y.clone();
+        self.compensation = (t.clone() - self.sum.clone()) - y;
+        self.sum = t;
+    }
+
+    /// Subtract one value from the running sum.
+    pub fn subtract(&mut self, value: T)
+    where
+        T: Zero,
+    {
+        self.add(T::zero() - value);
+    }
+
+    /// Return the current compensated running sum.
+    #[must_use]
+    pub fn value(&self) -> T {
+        self.sum.clone()
+    }
+}
+
+impl<T> KahanSum<T>
+where
+    T: Zero,
+{
+    /// Reset the accumulator to zero.
+    pub fn reset(&mut self) {
+        self.sum = T::zero();
+        self.compensation = T::zero();
+    }
+}
+
+impl<T> AddAssign<T> for KahanSum<T>
+where
+    T: Clone + Add<T, Output = T> + Sub<T, Output = T>,
+{
+    fn add_assign(&mut self, rhs: T) {
+        self.add(rhs);
+    }
+}
+
+impl<T> SubAssign<T> for KahanSum<T>
+where
+    T: Clone + Add<T, Output = T> + Sub<T, Output = T> + Zero,
+{
+    fn sub_assign(&mut self, rhs: T) {
+        self.subtract(rhs);
+    }
+}
 
 /// Modified Bessel function of the first kind, order 0.
 ///
@@ -116,6 +205,51 @@ pub fn erf<T: Erf>(x: T) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn kahan_sum_accumulates_values() {
+        let mut sum = KahanSum::default();
+
+        sum += 1.0_f32;
+        sum += 2.0;
+        sum += 3.0;
+
+        assert_eq!(sum.value(), 6.0);
+    }
+
+    #[test]
+    fn kahan_sum_subtracts_values() {
+        let mut sum = KahanSum::default();
+
+        sum += 10.0_f32;
+        sum.subtract(3.0);
+        sum -= 2.0;
+
+        assert_eq!(sum.value(), 5.0);
+    }
+
+    #[test]
+    fn kahan_sum_reduces_repeated_small_increment_error() {
+        let mut kahan = KahanSum::default();
+        let mut plain = 0.0_f32;
+        for _ in 0..10_000 {
+            kahan += 0.1;
+            plain += 0.1;
+        }
+
+        let expected = 1_000.0_f32;
+        assert!((kahan.value() - expected).abs() < (plain - expected).abs());
+    }
+
+    #[test]
+    fn kahan_sum_reset_clears_state() {
+        let mut sum = KahanSum::default();
+        sum.add(1.0_f32);
+
+        sum.reset();
+
+        assert_eq!(sum.value(), 0.0);
+    }
 
     #[cfg(any(feature = "libm", feature = "std"))]
     #[test]


### PR DESCRIPTION
- Add `math::KahanSum<T>`, a compensated accumulator for long-running sums that repeatedly
add small deltas.
- Add `filters::iir::integrate::KahanIntegrate<T>`, a compensated cumulative-sum filter backed by
`math::KahanSum<T>`.