### PR TITLE
Add Kaiser FIR order helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,15 @@ Please make sure to add your changes to the appropriate categories:
 - Add `KahanIntegrate<T>`, a compensated cumulative-sum filter backed by `KahanSum<T>`
 - Added `fir::design::windowed_sinc` module with per-window submodules for slice-filling low-pass, high-pass, band-pass, and band-stop FIR tap generation
 - Added `KaiserSinc::highpass_with_beta`, `KaiserSinc::bandpass_with_beta`, and `KaiserSinc::bandstop_with_beta` constructors (with `_hz` variants) for Kaiser-windowed filters with custom `β`
+- Added Kaiser FIR order-design helpers in `filters::fir::design`
+- Added Kaiser-windowed low-pass convenience helpers in `windowed_sinc::kaiser`
 
 ### Changed
 
 - `Biquad<T>` generalized to `Biquad<T, K = T>` with separate coefficient type; `Config<T>` renamed to `Config<K>` (breaks explicit `Config<f32>` references)
 - `BiquadCascade<T, CS, SS>` generalized to `BiquadCascade<T, CS, SS, K = T>` and its type aliases (`BiquadCascadeArray`, `BiquadCascadeVec`, `BiquadCascadeRefMut`) gained a `K` parameter
 - Relaxed `State<T>` / `Biquad<T>` default bounds from `Num` to `Zero` for state initialization
+- `Kaiser::Config::beta_for_attenuation` now delegates to `filters::fir::design::kaiser_beta`; the boundary at exactly 50 dB now uses the mid-attenuation formula (matching SciPy) instead of the high-attenuation formula
 
 ### Deprecated
 

--- a/src/filters/fir/design.rs
+++ b/src/filters/fir/design.rs
@@ -41,12 +41,12 @@
 //!
 //! # Feature flags
 //!
-//! Raised-cosine and square-root raised-cosine design require either `std` or
-//! `libm`. GMSK Gaussian pulse design requires `libm` for error-function
-//! support.
+//! Raised-cosine, square-root raised-cosine, Kaiser order estimation, and
+//! windowed-sinc design require either `std` or `libm`. GMSK Gaussian pulse
+//! design requires `libm` for error-function support.
 
 #[cfg(any(feature = "libm", feature = "std"))]
-use num_traits::Float;
+use num_traits::{Float, ToPrimitive};
 
 #[cfg(feature = "libm")]
 pub mod gaussian_pulse;
@@ -70,6 +70,274 @@ pub enum Normalization {
     UnitPeak,
     /// Scale taps so `sum(h[k]) == 1`.
     PassbandGain,
+}
+
+/// Kaiser FIR design parameters computed from a transition-width specification.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct KaiserOrder<T = f32> {
+    /// Number of taps.
+    pub num_taps: usize,
+    /// Kaiser shape parameter.
+    pub beta: T,
+}
+
+/// Compute the Kaiser window shape parameter from stop-band attenuation in dB.
+///
+/// This follows the empirical formula used by `SciPy`'s `scipy.signal.kaiser_beta`:
+///
+/// - `A <= 21 dB`: `β = 0`
+/// - `21 < A <= 50 dB`: `β = 0.5842 * (A - 21)^0.4 + 0.07886 * (A - 21)`
+/// - `A > 50 dB`: `β = 0.1102 * (A - 8.7)`
+///
+/// The two analytic arms join with a small discontinuity at `A = 50 dB`; this
+/// is inherent to the empirical fit and matches `SciPy`.
+///
+/// # References
+///
+/// Oppenheim, Schafer, "Discrete-Time Signal Processing", p.475-476.
+///
+/// # Panics
+///
+/// Panics if `atten_db` is not finite or is negative.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_beta<T>(atten_db: T) -> T
+where
+    T: Float + core::fmt::Debug,
+{
+    assert!(
+        atten_db.is_finite(),
+        "Kaiser attenuation must be finite (got {atten_db:?})"
+    );
+    assert!(
+        atten_db >= T::zero(),
+        "Kaiser attenuation must be non-negative (got {atten_db:?})"
+    );
+    let twenty_one = T::from(21.0).unwrap();
+    let fifty = T::from(50.0).unwrap();
+
+    // Standard Kaiser beta approximation from Oppenheim/Schafer and SciPy.
+    if atten_db > fifty {
+        T::from(0.1102).unwrap() * (atten_db - T::from(8.7).unwrap())
+    } else if atten_db > twenty_one {
+        let a_minus_21 = atten_db - twenty_one;
+        T::from(0.5842).unwrap() * a_minus_21.powf(T::from(0.4).unwrap())
+            + T::from(0.07886).unwrap() * a_minus_21
+    } else {
+        T::zero()
+    }
+}
+
+/// Estimate Kaiser FIR attenuation in dB from tap count and transition width.
+///
+/// `transition_width` is in cycles per sample, where Nyquist is `0.5`. This
+/// uses the same formula as `SciPy`'s `scipy.signal.kaiser_atten`, but not the
+/// same width convention. Use [`kaiser_atten_nyq`] for SciPy-compatible
+/// Nyquist-normalized widths.
+///
+/// # Panics
+///
+/// Panics if `num_taps` is zero, or if `transition_width` is not finite or is
+/// not in `(0, 0.5]`.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_atten<T>(num_taps: usize, transition_width: T) -> T
+where
+    T: Float + core::fmt::Debug,
+{
+    assert_kaiser_transition_width(transition_width);
+
+    kaiser_atten_nyq(num_taps, transition_width * T::from(2.0).unwrap())
+}
+
+/// Estimate Kaiser FIR attenuation in dB using `SciPy`'s width convention.
+///
+/// `width_nyq` is normalized to Nyquist, where `1.0` corresponds to
+/// π radians/sample. This matches `SciPy`'s `scipy.signal.kaiser_atten`
+/// convention.
+///
+/// Uses the empirical estimate `A = 2.285 * (num_taps - 1) * π * width_nyq + 7.95`,
+/// the inverse of the tap-count estimate used by [`kaiser_order_nyq`].
+///
+/// # References
+///
+/// Oppenheim, Schafer, "Discrete-Time Signal Processing", p.475-476.
+///
+/// # Panics
+///
+/// Panics if `num_taps` is zero, or if `width_nyq` is not finite or is not in
+/// `(0, 1]`.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_atten_nyq<T>(num_taps: usize, width_nyq: T) -> T
+where
+    T: Float + core::fmt::Debug,
+{
+    assert!(num_taps > 0, "Kaiser tap count must be > 0");
+    assert_kaiser_width_nyq(width_nyq);
+
+    T::from(2.285).unwrap()
+        * T::from(num_taps - 1).unwrap()
+        * T::from(core::f64::consts::PI).unwrap()
+        * width_nyq
+        + T::from(7.95).unwrap()
+}
+
+/// Determine Kaiser FIR tap count and β from attenuation and transition width.
+///
+/// `transition_width` is in cycles per sample, where Nyquist is `0.5`. This
+/// uses the same formula and tap-count behavior as `SciPy`'s
+/// `scipy.signal.kaiserord`, but not the same width convention. Use
+/// [`kaiser_order_nyq`] for SciPy-compatible Nyquist-normalized widths.
+///
+/// `atten_db` is interpreted by magnitude to match `SciPy`'s `kaiserord`
+/// behavior.
+///
+/// The tap-count formula and even/odd behavior match `SciPy`: the computed count
+/// is rounded up with `ceil` and is not forced odd.
+///
+/// # Panics
+///
+/// Panics if `atten_db` is not finite, if `abs(atten_db) < 8`, if
+/// `transition_width` is not finite or is not in `(0, 0.5]`, or if the computed
+/// tap count does not fit in `usize`.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_order<T>(atten_db: T, transition_width: T) -> KaiserOrder<T>
+where
+    T: Float + ToPrimitive + core::fmt::Debug,
+{
+    assert_kaiser_transition_width(transition_width);
+
+    kaiser_order_nyq(atten_db, transition_width * T::from(2.0).unwrap())
+}
+
+/// Determine Kaiser FIR tap count and β using `SciPy`'s width convention.
+///
+/// `width_nyq` is normalized to Nyquist, where `1.0` corresponds to
+/// π radians/sample. This matches `SciPy`'s `scipy.signal.kaiserord` convention.
+///
+/// `atten_db` is interpreted by magnitude to match `SciPy`'s `kaiserord`
+/// behavior.
+///
+/// The tap-count formula and even/odd behavior match `SciPy`: the computed count
+/// is rounded up with `ceil` and is not forced odd.
+///
+/// # Panics
+///
+/// Panics if `atten_db` is not finite, if `abs(atten_db) < 8`, if `width_nyq`
+/// is not finite or is not in `(0, 1]`, or if the computed tap count does not
+/// fit in `usize`.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_order_nyq<T>(atten_db: T, width_nyq: T) -> KaiserOrder<T>
+where
+    T: Float + ToPrimitive + core::fmt::Debug,
+{
+    assert!(
+        atten_db.is_finite(),
+        "Kaiser attenuation must be finite (got {atten_db:?})"
+    );
+    assert_kaiser_width_nyq(width_nyq);
+
+    // Match SciPy `kaiserord`: interpret the ripple/attenuation argument by
+    // magnitude, in case callers pass a negative decibel value.
+    let attenuation = atten_db.abs();
+    assert!(
+        attenuation >= T::from(8.0).unwrap(),
+        "Kaiser attenuation must be at least 8 dB (got {atten_db:?})"
+    );
+
+    let num_taps = ((attenuation - T::from(7.95).unwrap())
+        / (T::from(2.285).unwrap() * T::from(core::f64::consts::PI).unwrap() * width_nyq)
+        + T::one())
+    .ceil();
+    let num_taps = num_taps.to_usize().unwrap_or_else(|| {
+        panic!(
+            "Kaiser tap count {num_taps:?} does not fit in usize \
+             (attenuation {attenuation:?} dB, width_nyq {width_nyq:?}); \
+             reduce attenuation or increase transition width"
+        )
+    });
+
+    KaiserOrder {
+        num_taps,
+        beta: kaiser_beta(attenuation),
+    }
+}
+
+/// Determine Kaiser FIR design parameters from a transition width in Hz.
+///
+/// This is a convenience wrapper around [`kaiser_order`]. `sample_rate` and
+/// `transition_width_hz` must use the same units.
+///
+/// # Panics
+///
+/// Panics if `sample_rate` is not finite or not positive, if
+/// `transition_width_hz` is not finite or not positive, or if [`kaiser_order`]
+/// rejects the normalized transition width.
+#[cfg(any(feature = "libm", feature = "std"))]
+#[must_use]
+#[allow(clippy::unwrap_used)]
+pub fn kaiser_order_hz<T>(atten_db: T, transition_width_hz: T, sample_rate: T) -> KaiserOrder<T>
+where
+    T: Float + ToPrimitive + core::fmt::Debug,
+{
+    assert!(
+        sample_rate.is_finite(),
+        "sample_rate must be finite (got {sample_rate:?})"
+    );
+    assert!(
+        sample_rate > T::zero(),
+        "sample_rate must be > 0 (got {sample_rate:?})"
+    );
+    assert!(
+        transition_width_hz.is_finite(),
+        "transition_width_hz must be finite (got {transition_width_hz:?})"
+    );
+    assert!(
+        transition_width_hz > T::zero(),
+        "transition_width_hz must be > 0 (got {transition_width_hz:?})"
+    );
+
+    kaiser_order(atten_db, transition_width_hz / sample_rate)
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+fn assert_kaiser_transition_width<T>(transition_width: T)
+where
+    T: Float + core::fmt::Debug,
+{
+    assert!(
+        transition_width.is_finite(),
+        "Kaiser transition width must be finite (got {transition_width:?})"
+    );
+    assert!(
+        transition_width > T::zero()
+            && transition_width <= T::from(0.5).expect("0.5 is representable"),
+        "Kaiser transition width must be in (0, 0.5] cycles/sample (got {transition_width:?})"
+    );
+}
+
+#[cfg(any(feature = "libm", feature = "std"))]
+fn assert_kaiser_width_nyq<T>(width_nyq: T)
+where
+    T: Float + core::fmt::Debug,
+{
+    assert!(
+        width_nyq.is_finite(),
+        "Kaiser Nyquist-normalized width must be finite (got {width_nyq:?})"
+    );
+    assert!(
+        width_nyq > T::zero() && width_nyq <= T::one(),
+        "Kaiser Nyquist-normalized width must be in (0, 1] (got {width_nyq:?})"
+    );
 }
 
 #[cfg(any(feature = "libm", feature = "std"))]
@@ -161,5 +429,73 @@ pub(in crate::filters::fir::design) fn normalize_by_divisor<T>(
     let gain = T::one() / denom;
     for tap in taps {
         *tap = *tap * gain;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_abs_diff_eq;
+
+    use super::*;
+
+    #[test]
+    fn kaiser_beta_matches_scipy_examples() {
+        assert_abs_diff_eq!(kaiser_beta(65.0_f64), 6.20426, epsilon = 1e-5);
+        assert_abs_diff_eq!(kaiser_beta(40.0_f64), 3.395_321_052, epsilon = 1e-9);
+        assert_abs_diff_eq!(kaiser_beta(21.0_f64), 0.0, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn kaiser_atten_nyq_matches_scipy_example() {
+        let attenuation = kaiser_atten_nyq(211, 0.0375_f64);
+
+        assert_abs_diff_eq!(attenuation, 64.480_996_305_939_83, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn kaiser_atten_converts_cycles_per_sample_width() {
+        let cycles_per_sample = kaiser_atten(211, 9.0_f64 / 480.0);
+        let nyquist_normalized = kaiser_atten_nyq(211, 0.0375);
+
+        assert_abs_diff_eq!(cycles_per_sample, nyquist_normalized, epsilon = 1e-12);
+    }
+
+    #[test]
+    fn kaiser_order_nyq_matches_scipy_example() {
+        let order = kaiser_order_nyq(65.0_f64, 24.0 / 500.0);
+
+        assert_eq!(order.num_taps, 167);
+        assert_abs_diff_eq!(order.beta, 6.20426, epsilon = 1e-5);
+    }
+
+    #[test]
+    fn kaiser_order_converts_cycles_per_sample_width() {
+        let cycles_per_sample = kaiser_order(65.0_f64, 24.0 / 1000.0);
+        let nyquist_normalized = kaiser_order_nyq(65.0_f64, 24.0 / 500.0);
+
+        assert_eq!(cycles_per_sample, nyquist_normalized);
+    }
+
+    #[test]
+    fn kaiser_order_does_not_force_odd_tap_count() {
+        let order = kaiser_order(40.0_f64, 0.015);
+        let order_nyq = kaiser_order_nyq(40.0_f64, 0.03);
+
+        assert_eq!(order.num_taps, 150);
+        assert_eq!(order_nyq.num_taps, 150);
+    }
+
+    #[test]
+    fn kaiser_order_hz_matches_normalized_width() {
+        let normalized = kaiser_order(65.0_f64, 24.0 / 1000.0);
+        let hz = kaiser_order_hz(65.0_f64, 24.0, 1000.0);
+
+        assert_eq!(hz, normalized);
+    }
+
+    #[test]
+    #[should_panic(expected = "at least 8 dB")]
+    fn kaiser_order_rejects_too_little_attenuation() {
+        let _ = kaiser_order(7.9_f64, 0.1);
     }
 }

--- a/src/filters/fir/design/windowed_sinc.rs
+++ b/src/filters/fir/design/windowed_sinc.rs
@@ -220,6 +220,65 @@ windowed_sinc_module!(kaiser, super::default_kaiser::<T>(), "Kaiser (β=6.0)", {
         super::normalize(weights, super::Normalization::PassbandGain);
     }
 
+    /// Fill a slice with Kaiser-windowed low-pass sinc taps from Kaiser order parameters.
+    ///
+    /// `fc` is normalized cutoff frequency in cycles per sample (`0 < fc < 0.5`).
+    /// Taps are normalized to unit DC/passband gain (`sum(h) == 1`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `weights.len() != order.num_taps`, or if [`lowpass_with_beta`]
+    /// panics.
+    pub fn lowpass_from_order<T>(weights: &mut [T], order: super::super::KaiserOrder<T>, fc: T)
+    where
+        T: Float + core::fmt::Debug,
+    {
+        assert!(
+            weights.len() == order.num_taps,
+            "Kaiser tap count mismatch: expected {}, got {}",
+            order.num_taps,
+            weights.len()
+        );
+        lowpass_with_beta(weights, order.beta, fc);
+    }
+
+    /// Fill a slice with Kaiser-windowed low-pass sinc taps from attenuation and transition width.
+    ///
+    /// `transition_width` is in cycles per sample, where Nyquist is `0.5`. This
+    /// uses [`crate::filters::fir::design::kaiser_order`]. The computed tap
+    /// count is not forced odd.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`crate::filters::fir::design::kaiser_order`] panics, if
+    /// `weights.len() != order.num_taps`, or if [`lowpass_with_beta`] panics.
+    pub fn lowpass_for_atten<T>(weights: &mut [T], atten_db: T, transition_width: T, fc: T)
+    where
+        T: Float + num_traits::ToPrimitive + core::fmt::Debug,
+    {
+        let order = super::super::kaiser_order(atten_db, transition_width);
+        lowpass_from_order(weights, order, fc);
+    }
+
+    /// Fill a slice with Kaiser-windowed low-pass sinc taps from `SciPy`-style width.
+    ///
+    /// `width_nyq` is normalized to Nyquist, where `1.0` corresponds to
+    /// π radians/sample. This uses [`crate::filters::fir::design::kaiser_order_nyq`]
+    /// and matches `SciPy`'s `scipy.signal.kaiserord` width convention. The
+    /// computed tap count is not forced odd.
+    ///
+    /// # Panics
+    ///
+    /// Panics if [`crate::filters::fir::design::kaiser_order_nyq`] panics, if
+    /// `weights.len() != order.num_taps`, or if [`lowpass_with_beta`] panics.
+    pub fn lowpass_for_atten_nyq<T>(weights: &mut [T], atten_db: T, width_nyq: T, fc: T)
+    where
+        T: Float + num_traits::ToPrimitive + core::fmt::Debug,
+    {
+        let order = super::super::kaiser_order_nyq(atten_db, width_nyq);
+        lowpass_from_order(weights, order, fc);
+    }
+
     /// Fill a slice with Kaiser-windowed high-pass sinc taps using custom β.
     ///
     /// Taps are normalized to unit gain at Nyquist.
@@ -281,6 +340,52 @@ windowed_sinc_module!(kaiser, super::default_kaiser::<T>(), "Kaiser (β=6.0)", {
         let mut weights = alloc::vec![T::zero(); num_taps];
         lowpass_with_beta(&mut weights, beta, fc);
         weights
+    }
+
+    /// Create heap-backed Kaiser-windowed low-pass sinc taps from Kaiser order parameters.
+    ///
+    /// Taps are normalized to unit DC/passband gain (`sum(h) == 1`).
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn lowpass_from_order_vec<T>(
+        order: super::super::KaiserOrder<T>,
+        fc: T,
+    ) -> alloc::vec::Vec<T>
+    where
+        T: Float + core::fmt::Debug,
+    {
+        lowpass_with_beta_vec(order.num_taps, order.beta, fc)
+    }
+
+    /// Create heap-backed Kaiser-windowed low-pass sinc taps from attenuation and transition width.
+    ///
+    /// `transition_width` is in cycles per sample, where Nyquist is `0.5`. This
+    /// uses [`crate::filters::fir::design::kaiser_order`]. The computed tap
+    /// count is not forced odd.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn lowpass_for_atten_vec<T>(atten_db: T, transition_width: T, fc: T) -> alloc::vec::Vec<T>
+    where
+        T: Float + num_traits::ToPrimitive + core::fmt::Debug,
+    {
+        let order = super::super::kaiser_order(atten_db, transition_width);
+        lowpass_from_order_vec(order, fc)
+    }
+
+    /// Create heap-backed Kaiser-windowed low-pass sinc taps from `SciPy`-style width.
+    ///
+    /// `width_nyq` is normalized to Nyquist, where `1.0` corresponds to
+    /// π radians/sample. This uses [`crate::filters::fir::design::kaiser_order_nyq`]
+    /// and matches `SciPy`'s `scipy.signal.kaiserord` width convention. The
+    /// computed tap count is not forced odd.
+    #[cfg(feature = "alloc")]
+    #[must_use]
+    pub fn lowpass_for_atten_nyq_vec<T>(atten_db: T, width_nyq: T, fc: T) -> alloc::vec::Vec<T>
+    where
+        T: Float + num_traits::ToPrimitive + core::fmt::Debug,
+    {
+        let order = super::super::kaiser_order_nyq(atten_db, width_nyq);
+        lowpass_from_order_vec(order, fc)
     }
 
     /// Create heap-backed Kaiser-windowed high-pass sinc taps using custom β.

--- a/src/filters/fir/design/windowed_sinc/tests.rs
+++ b/src/filters/fir/design/windowed_sinc/tests.rs
@@ -183,6 +183,58 @@ fn kaiser_lowpass_with_beta_vec_helper_matches_in_place() {
     }
 }
 
+#[cfg(feature = "alloc")]
+#[test]
+fn kaiser_lowpass_from_order_vec_uses_order_parameters() {
+    let order = super::super::kaiser_order(65.0_f64, 24.0 / 1000.0);
+    let taps = super::kaiser::lowpass_from_order_vec(order, 0.175);
+
+    assert_eq!(taps.len(), 167);
+    assert_abs_diff_eq!(taps.iter().sum::<f64>(), 1.0, epsilon = 1e-12);
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn kaiser_lowpass_for_atten_vec_matches_in_place() {
+    let atten_db = 65.0_f64;
+    let transition_width = 24.0 / 1000.0;
+    let fc = 0.175;
+    let actual = super::kaiser::lowpass_for_atten_vec(atten_db, transition_width, fc);
+    let mut expected = std::vec![0.0; actual.len()];
+
+    super::kaiser::lowpass_for_atten(&mut expected, atten_db, transition_width, fc);
+
+    assert_eq!(actual.len(), 167);
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert_abs_diff_eq!(*actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn kaiser_lowpass_for_atten_nyq_vec_matches_cycles_per_sample_wrapper() {
+    let atten_db = 65.0_f64;
+    let width_nyq = 24.0 / 500.0;
+    let transition_width = 24.0 / 1000.0;
+    let fc = 0.175;
+    let actual = super::kaiser::lowpass_for_atten_nyq_vec(atten_db, width_nyq, fc);
+    let expected = super::kaiser::lowpass_for_atten_vec(atten_db, transition_width, fc);
+
+    assert_eq!(actual.len(), 167);
+    for (actual, expected) in actual.iter().zip(expected) {
+        assert_abs_diff_eq!(*actual, expected, epsilon = 1e-12);
+    }
+}
+
+#[test]
+#[should_panic(expected = "Kaiser tap count mismatch")]
+fn kaiser_lowpass_from_order_rejects_wrong_slice_len() {
+    let order = super::super::kaiser_order(65.0_f64, 24.0 / 1000.0);
+    let mut taps = [0.0; 33];
+
+    super::kaiser::lowpass_from_order(&mut taps, order, 0.175);
+}
+
 #[test]
 fn kaiser_with_beta_helpers_have_expected_reference_gain() {
     let beta = 8.0_f64;

--- a/src/filters/fir/window/kaiser.rs
+++ b/src/filters/fir/window/kaiser.rs
@@ -95,29 +95,15 @@ impl<T: Float + core::fmt::Debug, const N: usize> Config<T, [T; N]> {
 
     /// Compute Kaiser β for a desired sidelobe attenuation in dB.
     ///
-    /// Uses the Kaiser empirical formula:
-    /// - A ≤ 21 dB → β = 0
-    /// - 21 < A < 50 → β = 0.5842·(A−21)^0.4 + 0.07886·(A−21)
-    /// - A ≥ 50 → β = 0.1102·(A−8.7)
+    /// Delegates to [`crate::filters::fir::design::kaiser_beta`] so the
+    /// attenuation-to-β mapping is shared with FIR order design helpers.
     ///
-    /// The two analytic arms join with a small (~0.02) discontinuity at
-    /// `A = 50` dB; this is inherent to Kaiser & Reed's empirical fit and
-    /// not a defect.
+    /// # Panics
+    ///
+    /// Panics if `atten_db` is not finite or is negative.
     #[must_use]
     pub fn beta_for_attenuation(atten_db: T) -> T {
-        let zero = T::zero();
-        let twenty_one = T::from(21.0).unwrap();
-        let fifty = T::from(50.0).unwrap();
-
-        if atten_db <= twenty_one {
-            zero
-        } else if atten_db < fifty {
-            let a_minus_21 = atten_db - twenty_one;
-            T::from(0.5842).unwrap() * a_minus_21.powf(T::from(0.4).unwrap())
-                + T::from(0.07886).unwrap() * a_minus_21
-        } else {
-            T::from(0.1102).unwrap() * (atten_db - T::from(8.7).unwrap())
-        }
+        crate::filters::fir::design::kaiser_beta(atten_db)
     }
 }
 

--- a/src/filters/fir/window/kaiser/tests.rs
+++ b/src/filters/fir/window/kaiser/tests.rs
@@ -153,10 +153,9 @@ fn beta_for_attenuation_boundary_21() {
 #[cfg(any(feature = "libm", feature = "std"))]
 #[test]
 fn beta_for_attenuation_boundary_50() {
-    // Attenuation = 50 dB is the boundary between mid- and high-attenuation formulas.
+    // SciPy uses the mid-attenuation formula at exactly 50 dB.
     let beta = Config::<f64, [f64; 8]>::beta_for_attenuation(50.0);
-    // Expected from formula: 0.1102 * (50.0 - 8.7) = 0.1102 * 41.3 = 4.55126
-    assert_abs_diff_eq!(beta, 4.55126, epsilon = 1e-3);
+    assert_abs_diff_eq!(beta, 4.533_514_120_981_248, epsilon = 1e-12);
 }
 
 #[cfg(any(feature = "libm", feature = "std"))]


### PR DESCRIPTION
Add `filters::fir::design::{KaiserOrder, kaiser_beta, kaiser_atten, kaiser_atten_nyq,
kaiser_order, kaiser_order_nyq, kaiser_order_hz}` for sizing Kaiser-windowed FIR designs from
attenuation and transition-width specs.

Keep Signalo's primary `kaiser_atten` and `kaiser_order` helpers in cycles-per-sample units, where
Nyquist is `0.5`, to match the rest of the FIR tap-design API. Add the `_nyq` variants for SciPy's
`scipy.signal.kaiserord` and `scipy.signal.kaiser_atten` convention, where `1.0` is Nyquist.

Use SciPy's formula and tap-count behavior for both width conventions: compute `ceil(order + 1)`
and do not force the result odd. The cycles-per-sample helpers delegate to the `_nyq` variants with
`width_nyq = 2 * transition_width`.

Add `windowed_sinc::kaiser` low-pass convenience helpers that consume `KaiserOrder` or derive it
from attenuation and transition width, including `_nyq` wrappers for callers already using SciPy's
width convention.

Includes https://github.com/signalo/signalo/pull/178.