### PR TITLE
Add polyphase prototype packing helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Please make sure to add your changes to the appropriate categories:
 - Added `KaiserSinc::highpass_with_beta`, `KaiserSinc::bandpass_with_beta`, and `KaiserSinc::bandstop_with_beta` constructors (with `_hz` variants) for Kaiser-windowed filters with custom `β`
 - Added Kaiser FIR order-design helpers in `filters::fir::design`
 - Added Kaiser-windowed low-pass convenience helpers in `windowed_sinc::kaiser`
+- Added FIR polyphase prototype packing helpers:
+  - Added `packed_len` for computing the rectangular packed polyphase coefficient storage length given a number of phases and taps per phase
+  - Added `taps_per_phase_for_prototype_len` for computing taps per phase from a dense prototype length
+  - Added `packed_len_for_prototype_len` for computing packed polyphase storage length from a dense prototype length and number of phases
+  - Added `pack_prototype_taps` for copying and reordering a dense FIR prototype into phase-major rectangular polyphase coefficient storage
+  - Added `pack_prototype_taps_in_place` for in-place reordering of a padded dense prototype buffer into phase-major polyphase storage without a second allocation
 
 ### Changed
 

--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -9,6 +9,43 @@
 //! [`rational_resampler`] modules build streaming
 //! [`MultirateFilter`](crate::traits::MultirateFilter) adapters on top of those
 //! primitives.
+//!
+//! # Prototype design rates
+//!
+//! A dense prototype is the ordinary FIR tap sequence before it is split into
+//! polyphase branches. Its design rate is the sample rate where that FIR would
+//! run in the equivalent non-polyphase resampler. Frequency parameters such as
+//! cutoff frequencies and transition widths should be normalized to that same
+//! rate.
+//!
+//! | Case | Prototype design rate | Notes |
+//! | --- | --- | --- |
+//! | [Interpolator `L`](interpolator::PolyphaseInterpolator) | `input_rate * L` | The prototype runs at the output rate, where it suppresses interpolation images. |
+//! | [Decimator `M`](decimator::PolyphaseDecimator) | `input_rate` | The anti-aliasing filter sees the input-rate spectrum before downsampling. |
+//! | [Rational `L/M`](rational_resampler::RationalResampler) | `input_rate * L` | The filter runs at the intermediate rate after interpolation and before decimation. |
+//!
+//! For rational resamplers, `max(L, M)` is useful when choosing a low-pass
+//! anti-image and anti-aliasing prototype. At `input_rate * L`, the input
+//! Nyquist maps to `1 / (2L)` and the output Nyquist maps to `1 / (2M)`, so the
+//! lower Nyquist limit is `0.5 / max(L, M)`. Use that as the normalized
+//! boundary when choosing the prototype's passband edge, cutoff, and transition
+//! band for the desired image and alias rejection.
+//!
+//! # Prototype gain
+//!
+//! [`interpolator`] and [`rational_resampler`] do not apply interpolation gain
+//! scaling. If a prototype designer normalizes taps to unity passband gain,
+//! multiply the prototype coefficients by `L` before polyphase construction
+//! when unity amplitude should be preserved. This compensates for the
+//! interpolation step that inserts `L - 1` zero-valued samples between input
+//! samples. A unity-gain prototype preserves that upsampled sequence's
+//! `1 / L` baseband/DC gain, while scaling the prototype by `L` restores unity
+//! passband amplitude.
+//!
+//! Decimators are usually constructed with a unity-passband-gain prototype. A
+//! decimator is equivalent to filtering at the input rate and then keeping every
+//! `M`th output sample, so downsampling changes sample spacing but does not
+//! require any amplitude correction.
 
 pub mod decimator;
 pub mod filter_bank;

--- a/src/filters/fir/polyphase/decimator.rs
+++ b/src/filters/fir/polyphase/decimator.rs
@@ -51,11 +51,19 @@ pub struct State<R> {
 /// Coefficients follow the phase-major ordering described by
 /// [`PolyphaseFilterBank`].
 ///
+/// # Prototype design
+///
+/// For this M-to-1 decimator, design dense prototype taps at the input sample
+/// rate. The anti-aliasing filter sees the input-rate spectrum before
+/// downsampling.
+///
 /// # Gain
 ///
 /// This type does not apply gain correction after summing the phase outputs.
-/// Use a prototype filter with unity passband gain when unity-amplitude output
-/// is required.
+/// Decimators are usually constructed with a unity-passband-gain prototype. A
+/// decimator is equivalent to filtering at the input rate and then keeping every
+/// `M`th output sample, so downsampling changes sample spacing but does not
+/// require any amplitude correction.
 ///
 /// # Streaming
 ///

--- a/src/filters/fir/polyphase/filter_bank.rs
+++ b/src/filters/fir/polyphase/filter_bank.rs
@@ -3,6 +3,9 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 //! Polyphase FIR filter bank.
+//!
+//! See [`PolyphaseFilterBank`] for coefficient ordering and phase-major storage
+//! layout.
 
 use core::ops::{Add, Mul};
 
@@ -47,16 +50,26 @@ pub struct Config<C> {
 ///
 /// # Coefficient ordering
 ///
-/// Coefficients are stored phase-major in normal FIR order within each phase:
+/// Before packing, coefficients may be represented as a dense prototype: a
+/// single ordinary FIR coefficient sequence:
+///
+/// ```text
+/// h[0], h[1], h[2], h[3], ...
+/// ```
+///
+/// The packed representation is always rectangular: each phase has exactly
+/// `taps_per_phase` coefficients, with zero padding in shorter final branches
+/// when a dense prototype does not fill the rectangle. It stores one contiguous
+/// slice per phase. For `P = num_phases`, phase `p` stores every `P`-th
+/// prototype tap:
 ///
 /// ```text
 /// phase p: h[p], h[p + P], h[p + 2P], ...
 /// ```
 ///
-/// where `P = num_phases`. [`Self::execute`] accepts sample history in
-/// oldest-to-newest order. For the selected phase, the first phase coefficient
-/// is applied to the newest sample, matching normal FIR convolution coefficient
-/// semantics.
+/// [`Self::execute`] accepts sample history in oldest-to-newest order. It pairs
+/// coefficients with samples in convolution order: for the selected phase, the
+/// first phase coefficient is applied to the newest sample.
 ///
 /// The bank does not reverse, conjugate, or otherwise reinterpret
 /// coefficients. For correlation or matched-filter behavior, prepare those FIR
@@ -79,8 +92,8 @@ pub struct Config<C> {
 ///
 /// # Complexity
 ///
-/// - **Time per sample:** O(H/P) per [`Self::execute`] call, where H is the total tap count and
-///   P the number of phases; each call convolves one phase branch of H/P coefficients.
+/// - **Time per [`Self::execute`] call:** O(H/P), where H is the total tap count
+///   and P is the number of phases; each call convolves one phase branch of H/P coefficients.
 /// - **Space:** O(H); stores all H coefficients, but owns no delay-line state.
 #[derive(Clone, Debug)]
 pub struct PolyphaseFilterBank<C> {
@@ -96,6 +109,203 @@ pub type PolyphaseFilterBankVec<K> = PolyphaseFilterBank<alloc::vec::Vec<K>>;
 
 /// A polyphase filter bank that borrows caller-owned coefficient storage.
 pub type PolyphaseFilterBankRefMut<'a, K> = PolyphaseFilterBank<&'a mut [K]>;
+
+/// Returns the length of a packed polyphase coefficient slice.
+///
+/// The packed slice stores `num_phases` contiguous phase branches, with
+/// `taps_per_phase` coefficients in each branch:
+///
+/// ```text
+/// [phase 0 taps..., phase 1 taps..., ..., phase P - 1 taps...]
+/// ```
+///
+/// The total length is `num_phases * taps_per_phase`, which is the storage
+/// length expected by [`PolyphaseFilterBank`].
+///
+/// # Panics
+///
+/// Panics when `num_phases` or `taps_per_phase` is zero, or if the product
+/// overflows `usize`.
+#[must_use]
+pub const fn packed_len(num_phases: usize, taps_per_phase: usize) -> usize {
+    assert!(
+        num_phases > 0,
+        "PolyphaseFilterBank: number of phases must be > 0"
+    );
+    assert!(
+        taps_per_phase > 0,
+        "PolyphaseFilterBank: taps per phase must be > 0"
+    );
+    let Some(len) = num_phases.checked_mul(taps_per_phase) else {
+        panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
+    };
+    len
+}
+
+/// Returns the per-phase tap count needed to pack `prototype_len` dense
+/// prototype taps.
+///
+/// Dense prototype taps are distributed across phases by tap index. This returns
+/// `ceil(prototype_len / num_phases)`, the number of taps needed by each phase
+/// after the shorter final branches are zero-padded to a rectangular packed
+/// layout.
+///
+/// # Panics
+///
+/// Panics when `num_phases` or `prototype_len` is zero.
+#[must_use]
+pub const fn taps_per_phase_for_prototype_len(num_phases: usize, prototype_len: usize) -> usize {
+    assert!(
+        num_phases > 0,
+        "PolyphaseFilterBank: number of phases must be > 0"
+    );
+    assert!(
+        prototype_len > 0,
+        "PolyphaseFilterBank: tap count must be > 0"
+    );
+    prototype_len.div_ceil(num_phases)
+}
+
+/// Returns the packed coefficient length needed to store `prototype_len` dense
+/// prototype taps.
+///
+/// This is `num_phases * ceil(prototype_len / num_phases)`, i.e. the dense
+/// prototype length rounded up to a rectangular phase-major coefficient layout.
+///
+/// # Panics
+///
+/// Panics when `num_phases` or `prototype_len` is zero, or if the packed length
+/// overflows `usize`.
+#[must_use]
+pub const fn packed_len_for_prototype_len(num_phases: usize, prototype_len: usize) -> usize {
+    let taps_per_phase = taps_per_phase_for_prototype_len(num_phases, prototype_len);
+    packed_len(num_phases, taps_per_phase)
+}
+
+/// Packs dense prototype taps into rectangular phase-major coefficient storage.
+///
+/// Dense prototype taps are ordered as:
+///
+/// ```text
+/// h[0], h[1], h[2], h[3], ...
+/// ```
+///
+/// For `num_phases = P`, phase `p` receives every `P`-th tap:
+///
+/// ```text
+/// phase p: h[p], h[p + P], h[p + 2P], ...
+/// ```
+///
+/// The output `coefficients` slice uses phase-major storage:
+///
+/// ```text
+/// [phase 0 taps..., phase 1 taps..., ..., phase P - 1 taps...]
+/// ```
+///
+/// `coefficients.len()` chooses the rectangular packed geometry. It must be a
+/// nonzero multiple of `num_phases`. Any packed entries not covered by
+/// `prototype` are zero-filled, so callers may preallocate a larger fixed
+/// per-phase length than the minimum required by the prototype.
+///
+/// # Tap interpretation
+///
+/// This is only a storage transform; it does not reverse, conjugate, or
+/// otherwise reinterpret `prototype`. When the packed taps are used with
+/// [`PolyphaseFilterBank::execute`], `prototype` must already use that method's
+/// convolution coefficient order. For correlation or matched filtering through
+/// that executor, time-reverse the template first; for complex templates,
+/// conjugate it as well. For other executors, prepare the prototype in the order
+/// they expect before packing.
+///
+/// # Panics
+///
+/// Panics when `num_phases` is zero, `prototype` is empty, `coefficients` is
+/// empty, `coefficients.len()` is not a multiple of `num_phases`, or
+/// `prototype.len() > coefficients.len()`.
+pub fn pack_prototype_taps<K>(coefficients: &mut [K], num_phases: usize, prototype: &[K])
+where
+    K: Clone + Zero,
+{
+    assert!(
+        num_phases > 0,
+        "PolyphaseFilterBank: number of phases must be > 0"
+    );
+    assert!(
+        !prototype.is_empty(),
+        "PolyphaseFilterBank: tap count must be > 0"
+    );
+    assert!(
+        !coefficients.is_empty(),
+        "PolyphaseFilterBank: coefficient storage must be nonempty"
+    );
+    assert!(
+        coefficients.len().is_multiple_of(num_phases),
+        "PolyphaseFilterBank: coefficient count must be a multiple of num_phases"
+    );
+    assert!(
+        prototype.len() <= coefficients.len(),
+        "PolyphaseFilterBank: prototype length must fit coefficient storage"
+    );
+
+    let taps_per_phase = coefficients.len() / num_phases;
+    crate::math::matrix_transpose_padded(
+        coefficients,
+        prototype,
+        num_phases,
+        taps_per_phase,
+        K::zero(),
+    );
+}
+
+/// Packs dense prototype taps into rectangular phase-major storage in place.
+///
+/// `coefficients[..prototype_len]` is treated as the dense prototype. The tail
+/// `coefficients[prototype_len..]` is zero-filled, then the full slice is
+/// reordered into the phase-major layout described by [`pack_prototype_taps`].
+/// See [`pack_prototype_taps`] for tap ordering and interpretation.
+///
+/// `coefficients.len()` chooses the rectangular packed geometry, with the same
+/// rules as [`pack_prototype_taps`]. Use [`packed_len_for_prototype_len`] to get
+/// the minimum buffer length for `prototype_len`, or a larger multiple of
+/// `num_phases` to use a fixed per-phase length.
+///
+/// # Panics
+///
+/// Panics when `num_phases` or `prototype_len` is zero, `coefficients` is empty,
+/// `coefficients.len()` is not a multiple of `num_phases`, or
+/// `prototype_len > coefficients.len()`.
+pub fn pack_prototype_taps_in_place<K>(
+    coefficients: &mut [K],
+    num_phases: usize,
+    prototype_len: usize,
+) where
+    K: Clone + Zero,
+{
+    assert!(
+        num_phases > 0,
+        "PolyphaseFilterBank: number of phases must be > 0"
+    );
+    assert!(
+        prototype_len > 0,
+        "PolyphaseFilterBank: tap count must be > 0"
+    );
+    assert!(
+        !coefficients.is_empty(),
+        "PolyphaseFilterBank: coefficient storage must be nonempty"
+    );
+    assert!(
+        coefficients.len().is_multiple_of(num_phases),
+        "PolyphaseFilterBank: coefficient count must be a multiple of num_phases"
+    );
+    assert!(
+        prototype_len <= coefficients.len(),
+        "PolyphaseFilterBank: prototype length must fit coefficient storage"
+    );
+
+    let taps_per_phase = coefficients.len() / num_phases;
+    coefficients[prototype_len..].fill(K::zero());
+    crate::math::matrix_transpose_in_place(coefficients, num_phases, taps_per_phase);
+}
 
 impl<C> PolyphaseFilterBank<C> {
     /// Creates a [`PolyphaseFilterBank`] from phase-major coefficient storage.
@@ -117,9 +327,7 @@ impl<C> PolyphaseFilterBank<C> {
             "PolyphaseFilterBank: taps per phase must be > 0"
         );
 
-        let Some(expected_taps) = config.num_phases.checked_mul(config.taps_per_phase) else {
-            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
-        };
+        let expected_taps = packed_len(config.num_phases, config.taps_per_phase);
 
         assert_eq!(
             config.coefficients.as_slice().len(),
@@ -215,9 +423,11 @@ where
     /// Creates a heap-backed filter bank from dense prototype coefficients.
     ///
     /// This convenience constructor allocates coefficient storage. `prototype`
-    /// is provided in normal tap order, not phase-major order. It is zero-padded
-    /// at the tail as needed, then packed using the phase-major coefficient
+    /// is provided as a dense prototype, not phase-major storage. It is
+    /// zero-padded at the tail as needed, then packed using the phase-major
     /// ordering described on [`PolyphaseFilterBank`].
+    ///
+    /// See [`pack_prototype_taps`] for tap ordering and interpretation.
     ///
     /// # Panics
     ///
@@ -234,21 +444,10 @@ where
             "PolyphaseFilterBank: tap count must be > 0"
         );
 
-        let taps_per_phase = prototype.len().div_ceil(num_phases);
-        let Some(total_taps) = num_phases.checked_mul(taps_per_phase) else {
-            panic!("PolyphaseFilterBank: num_phases * taps_per_phase overflowed");
-        };
-
+        let taps_per_phase = taps_per_phase_for_prototype_len(num_phases, prototype.len());
+        let total_taps = packed_len(num_phases, taps_per_phase);
         let mut coefficients = alloc::vec![K::zero(); total_taps];
-        for phase in 0..num_phases {
-            for tap in 0..taps_per_phase {
-                let src = tap * num_phases + phase;
-                if src < prototype.len() {
-                    let dst = phase * taps_per_phase + tap;
-                    coefficients[dst] = prototype[src].clone();
-                }
-            }
-        }
+        pack_prototype_taps(&mut coefficients, num_phases, prototype);
 
         Self::from_parts(Config {
             num_phases,
@@ -309,9 +508,76 @@ impl<C> Reset for PolyphaseFilterBank<C> {
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, PolyphaseFilterBank, PolyphaseFilterBankArray, PolyphaseFilterBankRefMut};
+    use super::{
+        pack_prototype_taps, pack_prototype_taps_in_place, packed_len,
+        packed_len_for_prototype_len, taps_per_phase_for_prototype_len, Config,
+        PolyphaseFilterBank, PolyphaseFilterBankArray, PolyphaseFilterBankRefMut,
+    };
     use crate::filters::fir::polyphase::test_support::Pair;
     use crate::traits::WithConfig;
+
+    #[test]
+    fn packed_lengths_match_phase_geometry() {
+        assert_eq!(packed_len(3, 2), 6);
+        assert_eq!(taps_per_phase_for_prototype_len(3, 5), 2);
+        assert_eq!(packed_len_for_prototype_len(3, 5), 6);
+        assert_eq!(taps_per_phase_for_prototype_len(4, 8), 2);
+        assert_eq!(packed_len_for_prototype_len(4, 8), 8);
+    }
+
+    #[test]
+    fn pack_prototype_taps_reorders_and_pads() {
+        let mut coefficients = [99; 6];
+
+        pack_prototype_taps(&mut coefficients, 3, &[1, 2, 3, 4, 5]);
+
+        assert_eq!(coefficients, [1, 4, 2, 5, 3, 0]);
+    }
+
+    #[test]
+    fn pack_prototype_taps_handles_exact_rectangles() {
+        let mut coefficients = [99; 6];
+
+        pack_prototype_taps(&mut coefficients, 3, &[1, 2, 3, 4, 5, 6]);
+
+        assert_eq!(coefficients, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn pack_prototype_taps_allows_larger_geometry() {
+        let mut coefficients = [99; 9];
+
+        pack_prototype_taps(&mut coefficients, 3, &[1, 2, 3, 4, 5]);
+
+        assert_eq!(coefficients, [1, 4, 0, 2, 5, 0, 3, 0, 0]);
+    }
+
+    #[test]
+    fn pack_prototype_taps_in_place_reorders_and_pads() {
+        let mut coefficients = [1, 2, 3, 4, 5, 99];
+
+        pack_prototype_taps_in_place(&mut coefficients, 3, 5);
+
+        assert_eq!(coefficients, [1, 4, 2, 5, 3, 0]);
+    }
+
+    #[test]
+    fn pack_prototype_taps_in_place_handles_exact_rectangles() {
+        let mut coefficients = [1, 2, 3, 4, 5, 6];
+
+        pack_prototype_taps_in_place(&mut coefficients, 3, 6);
+
+        assert_eq!(coefficients, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn pack_prototype_taps_in_place_allows_larger_geometry() {
+        let mut coefficients = [1, 2, 3, 4, 5, 99, 98, 97, 96];
+
+        pack_prototype_taps_in_place(&mut coefficients, 3, 5);
+
+        assert_eq!(coefficients, [1, 4, 0, 2, 5, 0, 3, 0, 0]);
+    }
 
     #[test]
     fn from_parts_accepts_phase_major_coefficients() {

--- a/src/filters/fir/polyphase/interpolator.rs
+++ b/src/filters/fir/polyphase/interpolator.rs
@@ -56,13 +56,19 @@ pub struct State {
 /// Coefficients follow the phase-major ordering described by
 /// [`PolyphaseFilterBank`](super::filter_bank::PolyphaseFilterBank).
 ///
+/// # Prototype design
+///
+/// For this 1-to-P interpolator, design dense prototype taps at
+/// `input_rate * P`, the interpolated output rate. Frequency parameters such as
+/// cutoff frequencies and transition widths should be normalized to that rate.
+///
 /// # Gain
 ///
-/// This type does not apply interpolation gain scaling. To preserve the input
-/// amplitude, the prototype filter must have passband gain equal to the
-/// interpolation factor. A unity-gain prototype therefore produces output
-/// attenuated by `1 / P`; multiply its coefficients by `P` before construction,
-/// or design the prototype with the required gain.
+/// This type does not apply interpolation gain scaling. If a prototype designer
+/// normalizes taps to unity passband gain, multiply the prototype coefficients
+/// by `P` before polyphase construction when unity amplitude should be
+/// preserved. This compensates for the interpolation step that inserts `P - 1`
+/// zero-valued samples between input samples.
 ///
 /// # Type aliases
 ///

--- a/src/filters/fir/polyphase/rational_resampler.rs
+++ b/src/filters/fir/polyphase/rational_resampler.rs
@@ -68,13 +68,21 @@ pub struct State {
 /// Coefficients follow the phase-major ordering described by
 /// [`PolyphaseFilterBank`](super::filter_bank::PolyphaseFilterBank).
 ///
+/// # Prototype design
+///
+/// For this P/Q rational resampler, design dense prototype taps at
+/// `input_rate * P`, the intermediate rate after interpolation and before
+/// decimation. For low-pass anti-image and anti-aliasing prototypes, the lower
+/// input/output Nyquist boundary at that intermediate rate is
+/// `0.5 / max(P, Q)`.
+///
 /// # Gain
 ///
-/// This type does not apply interpolation gain scaling. To preserve the input
-/// amplitude, the prototype filter must have passband gain equal to the
-/// interpolation factor. A unity-gain prototype therefore produces output
-/// attenuated by `1 / P`; multiply its coefficients by `P` before construction,
-/// or design the prototype with the required gain.
+/// This type does not apply interpolation gain scaling. If a prototype designer
+/// normalizes taps to unity passband gain, multiply the prototype coefficients
+/// by `P` before polyphase construction when unity amplitude should be
+/// preserved. This compensates for the interpolation step that inserts `P - 1`
+/// zero-valued samples between input samples.
 ///
 /// # Ratio reduction
 ///

--- a/src/math.rs
+++ b/src/math.rs
@@ -13,6 +13,131 @@ use num_traits::Zero;
 #[cfg(any(feature = "libm", feature = "std"))]
 use num_traits::Float;
 
+/// Transposes a row-major matrix into a separate output slice.
+///
+/// `input` has `height` rows and `width` columns. `output` receives the
+/// transposed matrix, which has `width` rows and `height` columns. Both slices
+/// must have length `width * height`. Supports rectangular matrices, not just
+/// square ones.
+///
+/// # Panics
+///
+/// Panics when either slice length is not `width * height`, including
+/// multiplication overflow.
+pub(crate) fn matrix_transpose<T: Clone>(
+    output: &mut [T],
+    input: &[T],
+    width: usize,
+    height: usize,
+) {
+    let Some(count) = width.checked_mul(height) else {
+        panic!("matrix_transpose: width * height overflowed");
+    };
+    assert_eq!(
+        input.len(),
+        count,
+        "matrix_transpose: input length must equal width * height"
+    );
+    assert_eq!(
+        output.len(),
+        count,
+        "matrix_transpose: output length must equal width * height"
+    );
+
+    for y in 0..height {
+        for x in 0..width {
+            output[x * height + y] = input[y * width + x].clone();
+        }
+    }
+}
+
+/// Transposes a row-major matrix prefix into a separate output slice.
+///
+/// `input` is treated as the prefix of a row-major matrix with `height` rows and
+/// `width` columns. `output` receives the transposed matrix, which has `width`
+/// rows and `height` columns. Missing input elements are filled with `padding`.
+/// The output slice must have length `width * height`, and `input.len()` must
+/// not exceed that length.
+///
+/// # Panics
+///
+/// Panics when `output.len() != width * height`, `input.len() > width * height`,
+/// or if `width * height` overflows.
+pub(crate) fn matrix_transpose_padded<T: Clone>(
+    output: &mut [T],
+    input: &[T],
+    width: usize,
+    height: usize,
+    padding: T,
+) {
+    let Some(count) = width.checked_mul(height) else {
+        panic!("matrix_transpose_padded: width * height overflowed");
+    };
+    assert!(
+        input.len() <= count,
+        "matrix_transpose_padded: input length must be <= width * height"
+    );
+    assert_eq!(
+        output.len(),
+        count,
+        "matrix_transpose_padded: output length must equal width * height"
+    );
+    if input.len() == count {
+        matrix_transpose(output, input, width, height);
+        return;
+    }
+
+    output.fill(padding);
+    for (src, value) in input.iter().enumerate() {
+        let x = src % width;
+        let y = src / width;
+        output[x * height + y] = value.clone();
+    }
+}
+
+/// Transposes a row-major matrix in place.
+///
+/// The matrix has `height` rows and `width` columns, and `matrix.len()` must be
+/// `width * height`. Supports rectangular matrices, not just square ones.
+///
+/// This uses a rotation-based in-place algorithm that avoids a full auxiliary
+/// matrix. It is not linear-time: for large matrices, prefer
+/// [`matrix_transpose`] when a separate output buffer is available.
+///
+/// # Complexity
+///
+/// Performs `O(width^2 * height^2 / 4)` element moves.
+///
+/// # Panics
+///
+/// Panics when `width * height != matrix.len()`, including multiplication
+/// overflow.
+pub(crate) fn matrix_transpose_in_place<T>(matrix: &mut [T], width: usize, height: usize) {
+    let Some(count) = width.checked_mul(height) else {
+        panic!("matrix_transpose_in_place: width * height overflowed");
+    };
+    assert_eq!(
+        matrix.len(),
+        count,
+        "matrix_transpose_in_place: matrix length must equal width * height"
+    );
+
+    // Each inner iteration rotates a window of `step` elements ending at `last`
+    // (exclusive). `step` starts at 1 and grows by `width - x - 1` per row,
+    // advancing the rotation boundary through the transposition permutation for
+    // column group `x`.
+    for x in 0..width {
+        let count_adjustment = width - x - 1;
+        let mut step = 1;
+        for y in 0..height {
+            let last = count - (y + x * height);
+            let first = last - step;
+            matrix[first..last].rotate_left(1);
+            step += count_adjustment;
+        }
+    }
+}
+
 /// Kahan compensated summation accumulator.
 ///
 /// Tracks a running sum plus a compensation term that estimates floating-point
@@ -205,6 +330,8 @@ pub fn erf<T: Erf>(x: T) -> T {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::vec;
+    use std::vec::Vec;
 
     #[test]
     fn kahan_sum_accumulates_values() {
@@ -249,6 +376,78 @@ mod tests {
         sum.reset();
 
         assert_eq!(sum.value(), 0.0);
+    }
+
+    #[test]
+    fn matrix_transpose_padded_handles_short_input() {
+        let input = [1, 2, 3, 4, 5];
+        let mut output = [99; 6];
+
+        matrix_transpose_padded(&mut output, &input, 3, 2, 0);
+
+        assert_eq!(output, [1, 4, 2, 5, 3, 0]);
+    }
+
+    #[test]
+    fn matrix_transpose_padded_handles_larger_output() {
+        let input = [1, 2, 3, 4, 5];
+        let mut output = [99; 9];
+
+        matrix_transpose_padded(&mut output, &input, 3, 3, 0);
+
+        assert_eq!(output, [1, 4, 0, 2, 5, 0, 3, 0, 0]);
+    }
+
+    #[test]
+    fn matrix_transpose_handles_rectangular_matrix() {
+        let input = [1, 2, 3, 4, 5, 6];
+        let mut output = [0; 6];
+
+        matrix_transpose(&mut output, &input, 3, 2);
+
+        assert_eq!(output, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn matrix_transpose_handles_square_matrix() {
+        let input = [1, 2, 3, 4];
+        let mut output = [0; 4];
+
+        matrix_transpose(&mut output, &input, 2, 2);
+
+        assert_eq!(output, [1, 3, 2, 4]);
+    }
+
+    #[test]
+    fn matrix_transpose_in_place_handles_rectangular_matrix() {
+        let mut matrix = [1, 2, 3, 4, 5, 6];
+
+        matrix_transpose_in_place(&mut matrix, 3, 2);
+
+        assert_eq!(matrix, [1, 4, 2, 5, 3, 6]);
+    }
+
+    #[test]
+    fn matrix_transpose_in_place_handles_square_matrix() {
+        let mut matrix = [1, 2, 3, 4];
+
+        matrix_transpose_in_place(&mut matrix, 2, 2);
+
+        assert_eq!(matrix, [1, 3, 2, 4]);
+    }
+
+    #[test]
+    fn matrix_transpose_in_place_matches_out_of_place() {
+        for (width, height) in [(4, 3), (3, 4), (1, 8), (8, 1), (4, 4), (3, 5)] {
+            let input: Vec<_> = (1..=width * height).collect();
+            let mut expected = vec![0; width * height];
+            matrix_transpose(&mut expected, &input, width, height);
+
+            let mut actual = input.clone();
+            matrix_transpose_in_place(&mut actual, width, height);
+
+            assert_eq!(actual, expected, "width={width} height={height}");
+        }
     }
 
     #[cfg(any(feature = "libm", feature = "std"))]


### PR DESCRIPTION

Add helpers for rectangular phase-major polyphase storage lengths, including `packed_len`,
`taps_per_phase_for_prototype_len`, and `packed_len_for_prototype_len`.

Add out-of-place and in-place dense prototype packers. `pack_prototype_taps` fills caller-provided
rectangular storage, while `pack_prototype_taps_in_place` lets callers create a dense prototype in
one padded buffer and reorder it without allocating a second coefficient table.

When designing dense prototypes for rate-changing PFBs, normalize frequency parameters such as cutoff
frequencies and transition widths to the rate where the dense prototype is sampled:

| Case | Prototype design rate | Notes |
| --- | --- | --- |
| Interpolator `L` | `input_rate * L` | Output-rate prototype; suppresses interpolation images. |
| Decimator `M` | `input_rate` | Anti-aliasing filter sees the input-rate spectrum. |
| Rational `L/M` | `input_rate * L` | Filter at the intermediate rate before decimation. |

For rational `L/M` resamplers, `max(L, M)` is useful when choosing a low-pass anti-image and
anti-aliasing prototype. At `input_rate * L`, the input Nyquist maps to `1 / (2L)` and the
output Nyquist maps to `1 / (2M)`, so the lower Nyquist limit is `0.5 / max(L, M)`. Use that
as the normalized boundary when choosing the prototype's passband edge, cutoff, and transition
band for the desired image and alias rejection.

Interpolators often need coefficient gain scaled by `L` if the prototype designer normalizes taps
to unity passband gain; scale the prototype coefficients before polyphase construction. This
compensates for interpolation zero insertion: inserting `L - 1` zero-valued samples between input
samples gives the upsampled sequence `1 / L` baseband/DC gain before filtering.

Decimators are usually constructed with unity-passband-gain prototypes. A decimator is equivalent
to filtering at the input rate and then keeping every `M`th output sample, so downsampling changes
sample spacing but does not require any amplitude correction.

For example, an interpolator can design, scale, and pack its prototype in one padded buffer:

```rust
use circular_buffer::HeapCircularBuffer;
use signalo::filters::fir::{
    design,
    polyphase::{filter_bank, interpolator::PolyphaseInterpolatorVec},
};
use signalo::storage::RingBuffer;

let interpolation_factor = 32;
let input_rate_hz = 1_000.0_f32;
let output_rate_hz = input_rate_hz * interpolation_factor as f32;
let transition_width_hz = 24.0_f32;
let cutoff_hz = 450.0_f32;
let cutoff = cutoff_hz / output_rate_hz;

// Derive the Kaiser order at the interpolated output rate.
let order = design::kaiser_order_hz(65.0_f32, transition_width_hz, output_rate_hz);

let packed_len = filter_bank::packed_len_for_prototype_len(
    interpolation_factor,
    order.num_taps,
);
let mut coefficients = vec![0.0_f32; packed_len];

// Generate the dense Kaiser-windowed low-pass prototype into the buffer prefix.
design::windowed_sinc::kaiser::lowpass_from_order(
    &mut coefficients[..order.num_taps],
    order,
    cutoff,
);
// Scale the unity-gain prototype so interpolation preserves passband amplitude.
for tap in &mut coefficients[..order.num_taps] {
    *tap *= interpolation_factor as f32;
}

// Reorder the dense prototype prefix into rectangular phase-major storage.
filter_bank::pack_prototype_taps_in_place(&mut coefficients, interpolation_factor, order.num_taps);

let taps_per_phase = filter_bank::taps_per_phase_for_prototype_len(
    interpolation_factor,
    order.num_taps,
);
let mut delay_line = HeapCircularBuffer::with_capacity(taps_per_phase);
for _ in 0..taps_per_phase {
    let _ = delay_line.push_back(0.0_f32);
}

let interpolator = PolyphaseInterpolatorVec::from_parts(
    filter_bank::Config {
        num_phases: interpolation_factor,
        taps_per_phase,
        coefficients,
    },
    delay_line,
);
```

Add crate-private matrix transpose helpers for exact, padded, and in-place transposition. Use
`pack_prototype_taps` inside `PolyphaseFilterBankVec::from_prototype_taps` so the Vec constructor
stays on the shared packing path.