### PR TITLE
Relax polyphase FIR output type constraints

### DIFF
--- a/src/filters/fir/polyphase.rs
+++ b/src/filters/fir/polyphase.rs
@@ -15,3 +15,63 @@ pub mod filter_bank;
 pub mod fir;
 pub mod interpolator;
 pub mod rational_resampler;
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use core::ops::{Add, Mul};
+
+    use num_traits::Zero;
+
+    /// Test-only bundle proving one PFB pass can run two parallel real filters.
+    ///
+    /// With `T = i32`, this stores two coefficient weights. As the dot-product output, it stores the
+    /// two corresponding output accumulators.
+    #[derive(Clone, Copy, Debug, PartialEq)]
+    pub(crate) struct Pair<T = i32> {
+        /// First parallel filter value.
+        pub(crate) first: T,
+        /// Second parallel filter value.
+        pub(crate) second: T,
+    }
+
+    impl<T> Add for Pair<T>
+    where
+        T: Add<Output = T>,
+    {
+        type Output = Self;
+
+        fn add(self, rhs: Self) -> Self {
+            Self {
+                first: self.first + rhs.first,
+                second: self.second + rhs.second,
+            }
+        }
+    }
+
+    impl<T> Zero for Pair<T>
+    where
+        T: Zero + Add<Output = T>,
+    {
+        fn zero() -> Self {
+            Self {
+                first: T::zero(),
+                second: T::zero(),
+            }
+        }
+
+        fn is_zero(&self) -> bool {
+            self.first.is_zero() && self.second.is_zero()
+        }
+    }
+
+    impl Mul<Pair> for i32 {
+        type Output = Pair;
+
+        fn mul(self, rhs: Pair) -> Pair {
+            Self::Output {
+                first: self * rhs.first,
+                second: self * rhs.second,
+            }
+        }
+    }
+}

--- a/src/filters/fir/polyphase/filter_bank.rs
+++ b/src/filters/fir/polyphase/filter_bank.rs
@@ -179,11 +179,12 @@ impl<C> PolyphaseFilterBank<C> {
     /// Panics if `phase >= self.num_phases()`, or if the number of samples
     /// yielded by `taps` does not equal `self.taps_per_phase()`.
     #[must_use]
-    pub fn execute<'a, T, K, I>(&self, phase: usize, taps: I) -> T
+    pub fn execute<'a, T, K, O, I>(&self, phase: usize, taps: I) -> O
     where
-        T: 'a + Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
+        T: 'a + Clone + Mul<K, Output = O>,
         K: Clone,
         C: AsSlice<K>,
+        O: Zero + Add<Output = O>,
         I: IntoIterator<Item = &'a T>,
     {
         let coefficients = self.phase_coefficients(phase);
@@ -192,7 +193,7 @@ impl<C> PolyphaseFilterBank<C> {
         let output =
             taps.by_ref()
                 .zip(coefficients.iter().rev())
-                .fold(T::zero(), |sum, (state, coeff)| {
+                .fold(O::zero(), |sum, (state, coeff)| {
                     count += 1;
                     sum + ((*state).clone() * (*coeff).clone())
                 });
@@ -309,6 +310,7 @@ impl<C> Reset for PolyphaseFilterBank<C> {
 #[cfg(test)]
 mod tests {
     use super::{Config, PolyphaseFilterBank, PolyphaseFilterBankArray, PolyphaseFilterBankRefMut};
+    use crate::filters::fir::polyphase::test_support::Pair;
     use crate::traits::WithConfig;
 
     #[test]
@@ -365,6 +367,37 @@ mod tests {
         assert_eq!(bank.execute(0, [10, 40].iter()), 80);
         assert_eq!(bank.execute(1, [20, 50].iter()), 200);
         assert_eq!(bank.execute(2, [30, 60].iter()), 360);
+    }
+
+    /// Bundled coefficients can produce an output type different from the input sample type.
+    ///
+    /// This keeps ordinary scalar FIRs unchanged while allowing callers such as ML-TED timing
+    /// recovery to evaluate interpolation and derivative taps over the same sample history.
+    #[test]
+    fn execute_can_return_a_different_output_type() {
+        let bank = PolyphaseFilterBankArray::<Pair, 2>::from_parts(Config {
+            num_phases: 1,
+            taps_per_phase: 2,
+            coefficients: [
+                Pair {
+                    first: 1,
+                    second: 2,
+                },
+                Pair {
+                    first: 3,
+                    second: 5,
+                },
+            ],
+        });
+
+        let out: Pair = bank.execute(0, [7, 11].iter());
+        assert_eq!(
+            out,
+            Pair {
+                first: 32,
+                second: 57
+            }
+        );
     }
 
     #[test]

--- a/src/filters/fir/polyphase/fir.rs
+++ b/src/filters/fir/polyphase/fir.rs
@@ -142,13 +142,7 @@ where
     }
 }
 
-impl<T, C, R, K> PolyphaseFir<T, C, R, K>
-where
-    T: Clone + Zero + Add<Output = T> + Mul<K, Output = T>,
-    K: Clone,
-    C: AsSlice<K>,
-    R: RingBuffer<T>,
-{
+impl<T, C, R, K> PolyphaseFir<T, C, R, K> {
     /// Evaluates `phase` against the current delay line.
     ///
     /// # Panics
@@ -156,7 +150,14 @@ where
     /// Panics if `phase >= self.num_phases()`, or if the current delay-line
     /// length does not equal `self.taps_per_phase()`.
     #[must_use]
-    pub fn execute(&self, phase: usize) -> T {
+    pub fn execute<O>(&self, phase: usize) -> O
+    where
+        T: Clone + Mul<K, Output = O>,
+        K: Clone,
+        C: AsSlice<K>,
+        R: RingBuffer<T>,
+        O: Zero + Add<Output = O>,
+    {
         self.bank.execute(phase, self.state.taps.iter())
     }
 }
@@ -293,6 +294,7 @@ mod tests {
     use super::{PolyphaseFir, PolyphaseFirArray, PolyphaseFirRefMut, State};
     use crate::filters::fir::convolve::{Config as ConvolveConfig, ConvolveArray};
     use crate::filters::fir::polyphase::filter_bank::Config;
+    use crate::filters::fir::polyphase::test_support::Pair;
     use crate::traits::{
         guts::{FromGuts, IntoGuts},
         Filter, Reset, WithConfig,
@@ -319,6 +321,40 @@ mod tests {
         assert_eq!(fir.execute(0), 60);
         assert_eq!(fir.execute(1), 90);
         assert_eq!(fir.execute(2), 120);
+    }
+
+    /// Bundled coefficients can produce an output type different from the input sample type.
+    ///
+    /// This keeps ordinary scalar FIRs unchanged while allowing callers such as ML-TED timing
+    /// recovery to evaluate interpolation and derivative taps over the same owned delay line.
+    #[test]
+    fn execute_can_return_a_different_output_type() {
+        let mut fir = PolyphaseFirArray::<i32, 2, 2, Pair>::with_config(Config {
+            num_phases: 1,
+            taps_per_phase: 2,
+            coefficients: [
+                Pair {
+                    first: 1,
+                    second: 2,
+                },
+                Pair {
+                    first: 3,
+                    second: 5,
+                },
+            ],
+        });
+
+        fir.push(7);
+        fir.push(11);
+
+        let out: Pair = fir.execute(0);
+        assert_eq!(
+            out,
+            Pair {
+                first: 32,
+                second: 57
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
Allow `PolyphaseFilterBank::execute` and `PolyphaseFir::execute` to return a dot-product output type that differs from the input sample type. Existing scalar FIR users continue to infer the original output type, while bundled coefficient types can produce bundled outputs.

The output type `O` must be the product accumulator: `T: Clone + Mul<K, Output = O>`, `K: Clone`, and `O: Zero + Add<Output = O>`. `PolyphaseFilterBank::execute` still requires coefficient storage that implements `AsSlice<K>`, and `PolyphaseFir::execute` still requires a delay line that implements `RingBuffer<T>`.

For example, an ML-TED can bundle interpolator and derivative taps in one coefficient type so one phase execution over one delay line returns both dot products:

```rust
use core::ops::{Add, Mul};
use num_traits::Zero;

#[derive(Clone, Copy)]
struct TedBranch {
    interp: f32,
    deriv: f32,
}

impl Add for TedBranch {
    type Output = Self;

    fn add(self, rhs: Self) -> Self {
        Self {
            interp: self.interp + rhs.interp,
            deriv: self.deriv + rhs.deriv,
        }
    }
}

impl Zero for TedBranch {
    fn zero() -> Self {
        Self { interp: 0.0, deriv: 0.0 }
    }

    fn is_zero(&self) -> bool {
        self.interp == 0.0 && self.deriv == 0.0
    }
}

impl Mul<TedBranch> for f32 {
    type Output = TedBranch;

    fn mul(self, rhs: TedBranch) -> TedBranch {
        TedBranch {
            interp: self * rhs.interp,
            deriv: self * rhs.deriv,
        }
    }
}

let out: TedBranch = fir.execute(phase);
let timing_error = out.interp * out.deriv;
```

This enables timing-recovery use cases such as maximum-likelihood TEDs, where interpolation and derivative taps should share one delay line and be evaluated in one phase execution.