### PR TITLE
Add `Reset` to every `Convolve` storage backend, `with_config` for `ConvolveVec`, zero-padded cold-start initial state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Please make sure to add your changes to the appropriate categories:
   - Added `packed_len_for_prototype_len` for computing packed polyphase storage length from a dense prototype length and number of phases
   - Added `pack_prototype_taps` for copying and reordering a dense FIR prototype into phase-major rectangular polyphase coefficient storage
   - Added `pack_prototype_taps_in_place` for in-place reordering of a padded dense prototype buffer into phase-major polyphase storage without a second allocation
+- Added [`RingBuffer::fill_with`](crate::storage::RingBuffer::fill_with), a trait method that replaces the entire ring buffer contents with `capacity()` values produced by a closure
+- Added [`WithConfig`](crate::traits::WithConfig) implementation for [`ConvolveVec`](crate::filters::fir::convolve::ConvolveVec), so heap-allocated convolution filters can be constructed from config without manually allocating and zero-filling a tap buffer
 
 ### Changed
 
@@ -40,6 +42,7 @@ Please make sure to add your changes to the appropriate categories:
 - `BiquadCascade<T, CS, SS>` generalized to `BiquadCascade<T, CS, SS, K = T>` and its type aliases (`BiquadCascadeArray`, `BiquadCascadeVec`, `BiquadCascadeRefMut`) gained a `K` parameter
 - Relaxed `State<T>` / `Biquad<T>` default bounds from `Num` to `Zero` for state initialization
 - `Kaiser::Config::beta_for_attenuation` now delegates to `filters::fir::design::kaiser_beta`; the boundary at exactly 50 dB now uses the mid-attenuation formula (matching SciPy) instead of the high-attenuation formula
+- `Convolve::reset` now fills the delay line in place via [`RingBuffer::fill_with`](crate::storage::RingBuffer::fill_with) instead of reconstructing from config; the `Reset` impl no longer requires `WithConfig`, making it available on `ConvolveVec` and `ConvolveRefMut`
 
 ### Deprecated
 

--- a/src/filters/fir/convolve.rs
+++ b/src/filters/fir/convolve.rs
@@ -100,9 +100,11 @@ pub type ConvolveArray<T, const N: usize, K = T> =
 /// A convolution filter backed by heap-allocated [`Vec`](alloc::vec::Vec) coefficients
 /// and a [`HeapCircularBuffer`] tap buffer.
 ///
-/// Requires the `alloc` feature. Use [`Convolve::from_parts`] to construct
-/// this variant, since the tap buffer cannot be `Default`-constructed without
-/// knowing the desired capacity at compile time.
+/// Requires the `alloc` feature. Construct via
+/// [`with_config`](WithConfig::with_config), which sizes the tap buffer from
+/// the coefficient count and zero-fills it for the standard cold start. Use
+/// [`Convolve::from_parts`] only to supply a caller-owned tap buffer or a
+/// non-zero initial history.
 #[cfg(feature = "alloc")]
 pub type ConvolveVec<T, K = T> = Convolve<T, alloc::vec::Vec<K>, HeapCircularBuffer<T>, K>;
 
@@ -230,6 +232,28 @@ where
             state,
             _pd: PhantomData,
         }
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<T, K> WithConfig for ConvolveVec<T, K>
+where
+    T: Num,
+    K: Num,
+{
+    type Output = Self;
+
+    /// Creates a [`ConvolveVec`] from a configuration, allocating a tap buffer
+    /// sized from the coefficient count and zero-filling it for the standard
+    /// zero-padded cold start.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `config.coefficients` is empty.
+    fn with_config(config: Self::Config) -> Self::Output {
+        let mut taps = HeapCircularBuffer::with_capacity(config.coefficients.len());
+        taps.fill_with(T::zero);
+        Self::from_parts(config, taps)
     }
 }
 

--- a/src/filters/fir/convolve.rs
+++ b/src/filters/fir/convolve.rs
@@ -275,18 +275,21 @@ impl<T, C, R, K> IntoGuts for Convolve<T, C, R, K> {
     }
 }
 
-impl<T, const N: usize, K> Reset for ConvolveArray<T, N, K>
+impl<T, C, R, K> Reset for Convolve<T, C, R, K>
 where
     T: Num,
-    K: Num,
+    R: RingBuffer<T>,
 {
-    fn reset(self) -> Self {
-        Self::with_config(self.config)
+    /// Restores the zero-padded cold-start state by refilling the delay line
+    /// in place, reusing the existing storage.
+    fn reset(mut self) -> Self {
+        self.state.taps.fill_with(T::zero);
+        self
     }
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize, K> ResetMut for ConvolveArray<T, N, K> where Self: Reset {}
+impl<T, C, R, K> ResetMut for Convolve<T, C, R, K> where Self: Reset {}
 
 impl<T, C, R, K> Filter<T> for Convolve<T, C, R, K>
 where

--- a/src/filters/fir/convolve/tests.rs
+++ b/src/filters/fir/convolve/tests.rs
@@ -206,6 +206,62 @@ fn array_and_vec_backends_are_equivalent() {
     }
 }
 
+/// Verifies that [`Reset`] restores a full window of zeros on every storage
+/// backend.
+///
+/// Fullness matters as much as the zeros: `filter` zips the taps against the
+/// reversed coefficients and `zip` stops at the shorter iterator, so an empty
+/// delay line would mispair rather than zero-pad.
+#[test]
+fn reset_zero_fills_the_delay_line() {
+    use crate::traits::{guts::IntoGuts, Filter, Reset, WithConfig};
+
+    const COEFFS: [f32; 4] = [1.0, 2.0, 4.0, 8.0];
+
+    fn dirty_then_reset<C, R>(mut filter: Convolve<f32, C, R>)
+    where
+        C: AsSlice<f32>,
+        R: RingBuffer<f32>,
+    {
+        let _ = filter.filter(1.0);
+        let (_, state) = filter.reset().into_guts();
+        assert_eq!(
+            RingBuffer::len(&state.taps),
+            RingBuffer::capacity(&state.taps),
+            "delay line must be full, not empty"
+        );
+        assert!(
+            state.taps.iter().all(|tap| *tap == 0.0),
+            "every tap must be zero after reset"
+        );
+    }
+
+    dirty_then_reset(ConvolveArray::<f32, 4>::with_config(Config {
+        coefficients: COEFFS,
+    }));
+
+    // Borrowed ring: the backend that rebuilding from a config could never reset.
+    let mut owned = zero_filled_fixed_ring::<f32, 4>();
+    dirty_then_reset(ConvolveRefMut::<f32, [f32; 4]>::from_parts(
+        Config {
+            coefficients: COEFFS,
+        },
+        &mut owned,
+    ));
+
+    #[cfg(feature = "alloc")]
+    {
+        let mut taps = circular_buffer::HeapCircularBuffer::<f32>::with_capacity(4);
+        taps.fill_with(|| 0.0);
+        dirty_then_reset(ConvolveVec::<f32>::from_parts(
+            Config {
+                coefficients: COEFFS.to_vec(),
+            },
+            taps,
+        ));
+    }
+}
+
 #[test]
 #[should_panic(expected = "Convolve: window size N must be > 0")]
 fn from_parts_zero_coefficients_panics() {

--- a/src/filters/fir/convolve/tests.rs
+++ b/src/filters/fir/convolve/tests.rs
@@ -175,27 +175,27 @@ normalized_case!(normalized_zero_sum, 3, [1.0, -1.0, 0.0], [1.0, -1.0, 0.0]);
 /// are compared with `assert_abs_diff_eq!` at epsilon 1e-6.  Any divergence
 /// here points to a construction or iteration-order bug in the generic `filter`
 /// implementation (Task 5 contract).
+///
+/// The coefficients are deliberately non-uniform. A box average cannot detect a
+/// tap/coefficient mispairing at all, because permuting a constant vector is a
+/// no-op, so the whole warm-up window would compare equal regardless.
 #[cfg(feature = "alloc")]
 #[test]
 fn array_and_vec_backends_are_equivalent() {
-    use circular_buffer::HeapCircularBuffer;
-
     use crate::traits::{Filter, WithConfig};
 
-    // 4-tap low-pass FIR (box average)
-    let coeffs: [f32; 4] = [0.25, 0.25, 0.25, 0.25];
+    // 4-tap FIR with distinguishable coefficients
+    let coeffs: [f32; 4] = [1.0, 2.0, 4.0, 8.0];
 
     // ConvolveArray — stack-allocated
     let mut array_filter = ConvolveArray::<f32, 4>::with_config(Config {
         coefficients: coeffs,
     });
 
-    // ConvolveVec — heap-allocated; capacity must match coefficient count
-    let taps = HeapCircularBuffer::<f32>::with_capacity(4);
-    let vec_config = Config {
-        coefficients: alloc::vec![0.25_f32, 0.25, 0.25, 0.25],
-    };
-    let mut vec_filter = ConvolveVec::<f32>::from_parts(vec_config, taps);
+    // ConvolveVec — heap-allocated; `with_config` sizes and zero-fills the taps
+    let mut vec_filter = ConvolveVec::<f32>::with_config(Config {
+        coefficients: coeffs.to_vec(),
+    });
 
     let input: [f32; 10] = [1.0, 2.0, 3.0, 4.0, 5.0, 4.0, 3.0, 2.0, 1.0, 0.0];
 
@@ -204,6 +204,43 @@ fn array_and_vec_backends_are_equivalent() {
         let vec_out = vec_filter.filter(x);
         assert_abs_diff_eq!(array_out, vec_out, epsilon = 1e-6);
     }
+}
+
+/// Verifies that `ConvolveVec::with_config` establishes the zero-padded
+/// cold-start state, so the impulse response reads back the coefficients in
+/// order rather than a partial or mispaired window.
+#[cfg(feature = "alloc")]
+#[test]
+fn vec_with_config_cold_starts_zero_padded() {
+    use crate::traits::{Filter, WithConfig};
+
+    // Exactly representable in f32, so the impulse response is the coefficients.
+    let coeffs = alloc::vec![1.0_f32, 2.0, 4.0, 8.0];
+    let mut filter = ConvolveVec::<f32>::with_config(Config {
+        coefficients: coeffs,
+    });
+
+    let out: Vec<f32> = [1.0_f32, 0.0, 0.0, 0.0, 0.0]
+        .iter()
+        .map(|&x| filter.filter(x))
+        .collect();
+
+    assert_abs_diff_eq!(
+        out.as_slice(),
+        [1.0_f32, 2.0, 4.0, 8.0, 0.0].as_slice(),
+        epsilon = 1e-6
+    );
+}
+
+#[cfg(feature = "alloc")]
+#[test]
+#[should_panic(expected = "Convolve: window size N must be > 0")]
+fn vec_with_config_empty_coefficients_panics() {
+    use crate::traits::WithConfig;
+
+    let _ = ConvolveVec::<f32>::with_config(Config {
+        coefficients: Vec::<f32>::new(),
+    });
 }
 
 /// Verifies that [`Reset`] restores a full window of zeros on every storage

--- a/src/filters/fir/polyphase/decimator.rs
+++ b/src/filters/fir/polyphase/decimator.rs
@@ -239,9 +239,7 @@ where
         let mut taps = alloc::vec::Vec::with_capacity(bank.num_phases());
         for _ in 0..bank.num_phases() {
             let mut tap_buffer = HeapCircularBuffer::with_capacity(bank.taps_per_phase());
-            for _ in 0..bank.taps_per_phase() {
-                let _ = tap_buffer.push_back(T::zero());
-            }
+            tap_buffer.fill_with(T::zero);
             taps.push(tap_buffer);
         }
         Self::from_parts(bank.into_guts(), taps)

--- a/src/filters/fir/polyphase/fir.rs
+++ b/src/filters/fir/polyphase/fir.rs
@@ -221,9 +221,7 @@ where
     pub fn from_prototype_taps(num_phases: usize, prototype: &[K]) -> Self {
         let bank = PolyphaseFilterBankVec::from_prototype_taps(num_phases, prototype);
         let mut taps = HeapCircularBuffer::with_capacity(bank.taps_per_phase());
-        for _ in 0..bank.taps_per_phase() {
-            let _ = taps.push_back(T::zero());
-        }
+        taps.fill_with(T::zero);
         Self::from_parts(bank.into_guts(), taps)
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -145,6 +145,17 @@ pub trait RingBuffer<T> {
 
     /// Removes all elements from the buffer.
     fn clear(&mut self);
+
+    /// Replaces the entire contents with `capacity()` values produced by `f`.
+    ///
+    /// Equivalent to [`clear`](Self::clear) followed by pushing `capacity()`
+    /// values. Note that the result is *full*, not empty: after this call
+    /// [`is_full`](Self::is_full) is `true` and [`is_empty`](Self::is_empty)
+    /// is `false`. `fill_with(T::zero)` establishes the zero-padded cold-start
+    /// state for a numeric delay line without requiring `T: Clone`.
+    fn fill_with<F>(&mut self, f: F)
+    where
+        F: FnMut() -> T;
 }
 
 impl<T, const N: usize> RingBuffer<T> for FixedCircularBuffer<T, N> {
@@ -196,6 +207,13 @@ impl<T, const N: usize> RingBuffer<T> for FixedCircularBuffer<T, N> {
 
     fn clear(&mut self) {
         (**self).clear();
+    }
+
+    fn fill_with<F>(&mut self, f: F)
+    where
+        F: FnMut() -> T,
+    {
+        (**self).fill_with(f);
     }
 }
 
@@ -250,6 +268,13 @@ impl<T> RingBuffer<T> for HeapCircularBuffer<T> {
     fn clear(&mut self) {
         (**self).clear();
     }
+
+    fn fill_with<F>(&mut self, f: F)
+    where
+        F: FnMut() -> T,
+    {
+        (**self).fill_with(f);
+    }
 }
 
 impl<T> RingBuffer<T> for &mut CircularBuffer<T> {
@@ -302,13 +327,18 @@ impl<T> RingBuffer<T> for &mut CircularBuffer<T> {
     fn clear(&mut self) {
         (**self).clear();
     }
+
+    fn fill_with<F>(&mut self, f: F)
+    where
+        F: FnMut() -> T,
+    {
+        (**self).fill_with(f);
+    }
 }
 
 pub(crate) fn zero_filled_fixed_ring<T: Num, const N: usize>() -> FixedCircularBuffer<T, N> {
     let mut buf = FixedCircularBuffer::new();
-    for _ in 0..N {
-        let _ = buf.push_back(T::zero());
-    }
+    RingBuffer::fill_with(&mut buf, T::zero);
     buf
 }
 


### PR DESCRIPTION
`Reset` was implemented only for `ConvolveArray`.
It rebuilt the filter through `with_config`, which only the array backend can do: for `ConvolveVec` that reallocates the tap buffer, and for `ConvolveRefMut` there is no way to build a `&mut CircularBuffer<T>` from a config.

`Reset` now refills the delay line in place instead.
The resulting state is identical, nothing is reallocated, and one blanket impl covers array, heap and borrowed storage.
The bound widens from `T: Num, K: Num` to `T: Num, R: RingBuffer<T>`.

`ConvolveVec` could only be built with `from_parts`, which takes the tap buffer as-is.
Its assertion compares the coefficient count against `taps.capacity()` and never against `taps.len()`, so a correctly sized but empty buffer is accepted.
Such a filter mispairs its coefficients, because `filter` zips the taps against the reversed coefficients and `zip` stops at the shorter iterator.
With coefficients `[1, 2, 4, 8]`, a unit impulse gives `8, 8, 8, 8` instead of `1, 2, 4, 8`.
The window recovers once the ring fills, so only the first `N - 1` outputs are wrong.

`ConvolveVec` now implements `WithConfig`, which sizes the tap buffer from the coefficient count and zero-fills it.
`from_parts` is unchanged and remains the way to supply a caller-owned buffer or a non-zero initial history.

`RingBuffer` now has `fill_with`, forwarding to the dependency's inherent method.
It replaces three hand-rolled `clear` plus `push_back` loops: `zero_filled_fixed_ring` and the two heap `from_prototype_taps` constructors.
