### PR TITLE
`Reset` polyphase filters in place on every storage backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Please make sure to add your changes to the appropriate categories:
 - Relaxed `State<T>` / `Biquad<T>` default bounds from `Num` to `Zero` for state initialization
 - `Kaiser::Config::beta_for_attenuation` now delegates to `filters::fir::design::kaiser_beta`; the boundary at exactly 50 dB now uses the mid-attenuation formula (matching SciPy) instead of the high-attenuation formula
 - `Convolve::reset` now fills the delay line in place via [`RingBuffer::fill_with`](crate::storage::RingBuffer::fill_with) instead of reconstructing from config; the `Reset` impl no longer requires `WithConfig`, making it available on `ConvolveVec` and `ConvolveRefMut`
+- Moved `Reset` from per-alias impls (e.g. `PolyphaseFirArray`, `PolyphaseDecimatorArray`) onto the generic types, using `fill_with(T::zero)` in place instead of rebuilding via `with_config`.
+- Relaxed the `Interpolator` and `RationalResampler` trait bounds from `WithConfig` to `PolyphaseFir: Reset`, delegating through the wrapped FIR.
 
 ### Deprecated
 

--- a/src/filters/fir/polyphase/decimator.rs
+++ b/src/filters/fir/polyphase/decimator.rs
@@ -282,23 +282,29 @@ impl<T, C, R, B, K> IntoGuts for PolyphaseDecimator<T, C, R, B, K> {
     }
 }
 
-impl<T, const N: usize, const H: usize, const P: usize, K> Reset
-    for PolyphaseDecimatorArray<T, N, H, P, K>
+impl<T, C, R, B, K> Reset for PolyphaseDecimator<T, C, R, B, K>
 where
     T: Num,
+    R: AsSlice<B>,
+    B: RingBuffer<T>,
 {
-    fn reset(self) -> Self {
-        Self::with_config(self.bank.into_guts())
+    /// Restores the zero-padded cold-start state by refilling every per-phase
+    /// delay line in place, reusing the existing storage.
+    ///
+    /// The commutator is rewound to the last branch, matching
+    /// [`from_parts`](Self::from_parts), so the first output after a reset
+    /// follows a full decimation block rather than arriving early.
+    fn reset(mut self) -> Self {
+        for taps in self.state.taps.as_mut_slice() {
+            taps.fill_with(T::zero);
+        }
+        self.state.phase = self.bank.num_phases() - 1;
+        self
     }
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize, const H: usize, const P: usize, K> ResetMut
-    for PolyphaseDecimatorArray<T, N, H, P, K>
-where
-    Self: Reset,
-{
-}
+impl<T, C, R, B, K> ResetMut for PolyphaseDecimator<T, C, R, B, K> where Self: Reset {}
 
 impl<T, C, R, B, K> MultirateFilter<T> for PolyphaseDecimator<T, C, R, B, K>
 where
@@ -443,6 +449,36 @@ mod tests {
         assert_eq!(decimator.process(&[10, 20, 30, 40], &mut []), (2, 0));
         assert_eq!(decimator.process(&[30], &mut output), (1, 1));
         assert_eq!(output, [100]);
+    }
+
+    /// Verifies that [`Reset`] zero-fills every per-phase delay line and rewinds
+    /// the commutator on the heap backend, which had no reset before.
+    #[cfg(feature = "alloc")]
+    #[test]
+    fn vec_reset_zero_fills_every_branch_and_rewinds_the_commutator() {
+        use crate::storage::{AsSlice, RingBuffer};
+
+        let mut decimator = super::PolyphaseDecimatorVec::<i32>::from_prototype_taps(3, &[1, 2, 3]);
+        // Consume one sample so the commutator is left mid-block and a tap is dirty.
+        assert_eq!(decimator.process(&[10], &mut []), (1, 0));
+
+        let (_, state) = decimator.reset().into_guts();
+        assert_eq!(
+            state.phase,
+            state.taps.as_slice().len() - 1,
+            "the commutator must rewind to the last branch, not to zero"
+        );
+        for taps in state.taps.as_slice() {
+            assert_eq!(
+                RingBuffer::len(taps),
+                RingBuffer::capacity(taps),
+                "every branch delay line must be full, not empty"
+            );
+            assert!(
+                taps.iter().all(|tap| *tap == 0),
+                "every tap must be zero after reset"
+            );
+        }
     }
 
     #[test]

--- a/src/filters/fir/polyphase/fir.rs
+++ b/src/filters/fir/polyphase/fir.rs
@@ -272,20 +272,21 @@ impl<T, C, R, K> IntoGuts for PolyphaseFir<T, C, R, K> {
     }
 }
 
-impl<T, const N: usize, const H: usize, K> Reset for PolyphaseFirArray<T, N, H, K>
+impl<T, C, R, K> Reset for PolyphaseFir<T, C, R, K>
 where
     T: Num,
+    R: RingBuffer<T>,
 {
-    fn reset(self) -> Self {
-        Self::with_config(self.bank.into_guts())
+    /// Restores the zero-padded cold-start state by refilling the delay line
+    /// in place, reusing the existing storage.
+    fn reset(mut self) -> Self {
+        self.state.taps.fill_with(T::zero);
+        self
     }
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize, const H: usize, K> ResetMut for PolyphaseFirArray<T, N, H, K> where
-    Self: Reset
-{
-}
+impl<T, C, R, K> ResetMut for PolyphaseFir<T, C, R, K> where Self: Reset {}
 
 #[cfg(test)]
 mod tests {
@@ -446,6 +447,57 @@ mod tests {
         });
 
         let _ = fir.execute(2);
+    }
+
+    /// Verifies that [`Reset`] restores a full window of zeros on every storage
+    /// backend, mirroring the equivalent `Convolve` test.
+    ///
+    /// Fullness matters as much as the zeros: `execute` pairs each branch's
+    /// coefficients against the delay line, so a short delay line would
+    /// mispair rather than zero-pad.
+    #[test]
+    fn reset_zero_fills_the_delay_line_on_every_backend() {
+        use crate::storage::{zero_filled_fixed_ring, AsSlice, RingBuffer};
+
+        const COEFFS: [i32; 4] = [1, 3, 2, 4];
+
+        fn dirty_then_reset<C, R>(mut fir: PolyphaseFir<i32, C, R>)
+        where
+            C: AsSlice<i32>,
+            R: RingBuffer<i32>,
+        {
+            fir.push(10);
+            let (_, state) = fir.reset().into_guts();
+            assert_eq!(
+                RingBuffer::len(&state.taps),
+                RingBuffer::capacity(&state.taps),
+                "delay line must be full, not empty"
+            );
+            assert!(
+                state.taps.iter().all(|tap| *tap == 0),
+                "every tap must be zero after reset"
+            );
+        }
+
+        let config = || Config {
+            num_phases: 2,
+            taps_per_phase: 2,
+            coefficients: COEFFS,
+        };
+
+        dirty_then_reset(PolyphaseFirArray::<i32, 4, 2>::with_config(config()));
+
+        // Borrowed ring: the backend that rebuilding from a config could never reset.
+        let mut owned = zero_filled_fixed_ring::<i32, 2>();
+        dirty_then_reset(PolyphaseFirRefMut::<'_, i32, [i32; 4]>::from_parts(
+            config(),
+            &mut owned,
+        ));
+
+        #[cfg(feature = "alloc")]
+        dirty_then_reset(super::PolyphaseFirVec::<i32>::from_prototype_taps(
+            2, &COEFFS,
+        ));
     }
 
     #[test]

--- a/src/filters/fir/polyphase/interpolator.rs
+++ b/src/filters/fir/polyphase/interpolator.rs
@@ -15,10 +15,7 @@ use crate::traits::{
     Config as ConfigTrait, ConfigClone, ConfigRef, MultirateFilter, Reset, WithConfig,
 };
 
-use super::{
-    filter_bank::Config,
-    fir::{PolyphaseFir, PolyphaseFirArray},
-};
+use super::{filter_bank::Config, fir::PolyphaseFir};
 
 #[cfg(feature = "alloc")]
 use circular_buffer::HeapCircularBuffer;
@@ -260,20 +257,19 @@ where
     }
 }
 
-impl<T, const N: usize, const H: usize, K> Reset for PolyphaseInterpolatorArray<T, N, H, K>
+impl<T, C, R, K> Reset for PolyphaseInterpolator<T, C, R, K>
 where
-    PolyphaseFirArray<T, N, H, K>: Reset,
+    PolyphaseFir<T, C, R, K>: Reset,
 {
+    /// Resets the wrapped FIR's delay line in place and rewinds the phase
+    /// counter to "no output pending".
     fn reset(self) -> Self {
         Self::from_fir(self.fir.reset())
     }
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize, const H: usize, K> ResetMut for PolyphaseInterpolatorArray<T, N, H, K> where
-    Self: Reset
-{
-}
+impl<T, C, R, K> ResetMut for PolyphaseInterpolator<T, C, R, K> where Self: Reset {}
 
 impl<T, C, R, K> MultirateFilter<T> for PolyphaseInterpolator<T, C, R, K>
 where

--- a/src/filters/fir/polyphase/rational_resampler.rs
+++ b/src/filters/fir/polyphase/rational_resampler.rs
@@ -15,10 +15,7 @@ use crate::traits::{
     Config as ConfigTrait, ConfigClone, MultirateFilter, Reset, WithConfig,
 };
 
-use super::{
-    filter_bank::Config as BankConfig,
-    fir::{PolyphaseFir, PolyphaseFirArray},
-};
+use super::{filter_bank::Config as BankConfig, fir::PolyphaseFir};
 
 #[cfg(feature = "alloc")]
 use circular_buffer::HeapCircularBuffer;
@@ -318,20 +315,19 @@ where
     }
 }
 
-impl<T, const N: usize, const H: usize, K> Reset for RationalResamplerArray<T, N, H, K>
+impl<T, C, R, K> Reset for RationalResampler<T, C, R, K>
 where
-    PolyphaseFirArray<T, N, H, K>: Reset,
+    PolyphaseFir<T, C, R, K>: Reset,
 {
+    /// Resets the wrapped FIR's delay line in place and rewinds the phase
+    /// accumulator to "no output pending".
     fn reset(self) -> Self {
         Self::from_fir(self.fir.reset(), self.decimation)
     }
 }
 
 #[cfg(feature = "derive")]
-impl<T, const N: usize, const H: usize, K> ResetMut for RationalResamplerArray<T, N, H, K> where
-    Self: Reset
-{
-}
+impl<T, C, R, K> ResetMut for RationalResampler<T, C, R, K> where Self: Reset {}
 
 impl<T, C, R, K> MultirateFilter<T> for RationalResampler<T, C, R, K>
 where


### PR DESCRIPTION
`Reset` was implemented only for the `*Array` aliases of `PolyphaseFir`, `PolyphaseInterpolator`, `PolyphaseDecimator` and `RationalResampler`, and each worked by rebuilding through `with_config`. That cannot extend to the other backends: for the `*Vec` aliases it reallocates the delay-line storage on every reset, and for the `*RefMut` aliases there is no way to build a borrowed ring from a config.

`PolyphaseFir` and `PolyphaseDecimator` now refill their delay lines in place, and `PolyphaseInterpolator` and `RationalResampler` relax to the generic type so they inherit that through the FIR they wrap, with their bodies unchanged. The
resulting state is identical, nothing is reallocated, and one blanket impl per type covers array, heap and borrowed storage.

`PolyphaseDecimator` also rewinds its commutator to the last branch, matching `from_parts`, so the first output after a reset follows a full decimation block rather than arriving early.

This mirrors the equivalent change to `Convolve` (https://github.com/signalo/signalo/pull/186).