### PR TITLE
Widen the root-raised-cosine singularity guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Widened the root-raised-cosine singularity guard from `4ε` to `√ε` so the closed-form limit is substituted across the full cancellation region instead of only on an exact hit; rolloff `α = 0.25001` at 4 samples per symbol no longer loses 11 bits of precision.
 
 ### Performance
 

--- a/src/filters/fir/design/root_raised_cosine.rs
+++ b/src/filters/fir/design/root_raised_cosine.rs
@@ -48,6 +48,10 @@ pub fn taps_with_norm<T>(
     let sqrt_2 = T::from(core::f64::consts::SQRT_2).expect("sqrt(2) is representable");
     let two = T::from(2.0).expect("2 is representable");
     let four = T::from(4.0).expect("4 is representable");
+    // Near |4αt| = 1 both the numerator and the denominator vanish linearly, so the direct
+    // form's cancellation error grows as ε/δ while the limit's truncation error grows as δ,
+    // where δ = |1 − (4αt)²|. The two cross at δ ≈ √ε, so that is the substitution threshold.
+    let singularity_guard = T::epsilon().sqrt();
     let inv_sps = T::one() / sps_t;
     let sqrt_sps = sps_t.sqrt();
     let Ok(half) = isize::try_from(samples / 2) else {
@@ -67,7 +71,7 @@ pub fn taps_with_norm<T>(
             (T::one() - rolloff + four * rolloff / pi) * sqrt_sps
         } else {
             let quad_denominator = T::one() - four_rolloff_time * four_rolloff_time;
-            if rolloff > T::zero() && quad_denominator.abs() <= T::epsilon() * four {
+            if rolloff > T::zero() && quad_denominator.abs() <= singularity_guard {
                 let s = (pi / (four * rolloff)).sin();
                 let c = (pi / (four * rolloff)).cos();
                 let g1 = T::one() + two / pi;

--- a/src/filters/fir/design/root_raised_cosine/tests.rs
+++ b/src/filters/fir/design/root_raised_cosine/tests.rs
@@ -74,6 +74,26 @@ fn passband_gain_normalizes_sum_to_one() {
 }
 
 #[test]
+fn f32_near_singularity_uses_the_stable_limit() {
+    const SPAN: usize = 8;
+    const SPS: usize = 4;
+    const LEN: usize = len_from_span(SPAN, SPS);
+    let rolloff = 0.250_01_f32;
+    let mut actual = [0.0_f32; LEN];
+    super::taps_with_norm(&mut actual, SPAN, SPS, rolloff, Normalization::None);
+
+    // At one symbol from the centre, 4αt differs from one by only about 4e-5. The direct form
+    // subtracts nearly equal terms, while the closed-form limit remains well conditioned.
+    let singular_index = LEN / 2 + SPS;
+    let pi = core::f32::consts::PI;
+    let expected = rolloff / core::f32::consts::SQRT_2
+        * ((1.0 + 2.0 / pi) * (pi / (4.0 * rolloff)).sin()
+            + (1.0 - 2.0 / pi) * (pi / (4.0 * rolloff)).cos())
+        * (SPS as f32).sqrt();
+    assert_abs_diff_eq!(actual[singular_index], expected, epsilon = 1.0e-6);
+}
+
+#[test]
 fn matched_filter_gives_raised_cosine_at_symbol_instants() {
     const SPAN: usize = 64;
     const SPS: usize = 8;


### PR DESCRIPTION
The guard substituted the closed-form limit only when the denominator sat within $4\varepsilon$ of zero:

    quad_denominator = 1 - (4at)^2
    if |quad_denominator| <= 4 * eps { substitute the limit }

That is far narrower than the region where the direct form loses precision. Both the numerator and the denominator vanish linearly at the singularity, so writing $\delta = |1 - (4\alpha t)^2|$, the two error terms behave as

$$\text{direct} \sim \frac{\varepsilon}{\delta}\ \text{(cancellation)}, \qquad \text{limit} \sim \delta\ \text{(truncation)}$$

and they cross at $\delta \sim \sqrt{\varepsilon}$. Measured against a 60-digit reference at $t = 1/(4\alpha)$, the crossover lands at $0.4$ to $1.5$ times $\sqrt{\varepsilon}$ across rolloffs from $0.1$ to $0.9$, for both `f32` and `f64`. Inside the old $\varepsilon$-wide guard the direct form had already lost most of its digits. At $\delta = 10^{-4}$ in `f32` the direct form is wrong by $1.1 \times 10^{-2}$ relative where the limit is wrong by $7.0 \times 10^{-4}$.

How other implementations handle the same singularity. Too wide means substituting the limit where the direct form would have been more accurate, which costs a bounded amount of accuracy on the taps nearest the singularity. Too narrow means evaluating the direct form inside the cancellation region, where the error is unbounded as a tap approaches the singularity.

- Octave `rcosdesign` sits closest to the crossover and is the only one that scales to the working precision. Its `tol = sqrt(eps)` on the distance in symbol time works out to $8\beta\sqrt{\varepsilon}$ here, so it is right on the crossover at $\beta = 0.125$ and $8\times$ too wide at $\beta = 1.0$:

      tol = sqrt (eps);
      idx_inf = (abs (abs (t) - 1 / (4 * max (beta, tol))) < tol);

  https://github.com/gnu-octave/octave-signal/blob/main/inst/rcosdesign.m#L46

- commpy `rrcosfilter` protects only an exact hit, so a near-miss is evaluated in the cancellation region with no bound on the error. That is the failure mode fixed here:

      elif alpha != 0 and t == Ts/(4*alpha):

  https://github.com/veeresht/CommPy/blob/master/commpy/filters.py#L108

- mhostetter/sdr moves `t` off the singularity instead of substituting. The displacement is well chosen, $10^{-8}$ being about $0.67$ times the crossover distance, but it also triggers only on an exact hit and so shares commpy's gap:

      t1 = Ts / (4 * alpha)
      t[t == -t1] -= 1e-8
      t[t == t1] += 1e-8

  https://github.com/mhostetter/sdr/blob/main/src/sdr/_modulation/_pulse_shapes.py#L452

- GNU Radio `firdes` is $67\times$ too wide. Its worst case is about $7 \times 10^{-6}$ relative on the taps nearest the singularity, far below the quantisation of any real pulse shaper, so this is suboptimal rather than harmful:

      x3 = x2 * x2 - 1;
      if (fabs(x3) >= 0.000001) { // Avoid Rounding errors...

  https://github.com/gnuradio/gnuradio/blob/main/gr-filter/lib/firdes.cc#L656

- liquid-dsp `rrcos` is $9.2\times$ too wide for its `f32` arithmetic, the largest error in the survey at roughly $2 \times 10^{-2}$ relative on the nearest tap in the worst case:

      float g = 1-16*_beta*_beta*z*z;
      g *= g;
      if ( g < 1e-5 ) {

  https://github.com/jgaeddert/liquid-dsp/blob/master/src/filter/src/rrcos.c#L78

Guarding $1 - (4\alpha t)^2$ directly, as here, stays near the crossover for every rolloff, where Octave's drifts with the rolloff because it measures the distance in symbol time instead.

Octave was checked by running it: version 11.3.0 against the unreleased `rcosdesign` from the signal package's main branch. The branch flip sits at exactly $8\beta\sqrt{\varepsilon}$ for $\beta \in \{0.125, 0.25, 0.5, 1.0\}$, and its taps agree with this crate's to $8.3 \times 10^{-17}$ for `rcosdesign(0.35, 4, 4)`.

Octave, commpy and liquid-dsp all substitute the same closed form used here:

$$\frac{\beta}{\sqrt{2}}\left[\left(1 + \frac{2}{\pi}\right) \sin\frac{\pi}{4\beta} + \left(1 - \frac{2}{\pi}\right) \cos\frac{\pi}{4\beta}\right]$$

The near-miss gap is not hypothetical: rolloff $0.25001$ at 4 samples per symbol lands $8 \times 10^{-5}$ away from the singularity, which the added test covers. Both remaining thresholds are hardcoded absolute constants, which is why this one derives from `T::epsilon()`: the crate is generic over `T: Float`, and $10^{-6}$ suits only `f64` while $3.2 \times 10^{-3}$ suits only `f32`.