### PR TITLE
[Optimization] Follow permutation cycles when transposing in place

### DIFF
--- a/src/filters/fir/polyphase/filter_bank.rs
+++ b/src/filters/fir/polyphase/filter_bank.rs
@@ -271,10 +271,9 @@ where
 ///
 /// # Complexity
 ///
-/// - **Time:** O((P·T)²/4) element moves, where P is `num_phases` and T is
-///   `coefficients.len() / num_phases`. The reorder is a rotation-based in-place
-///   transpose performing exactly `P·T + P(P−1)·T(T−1)/4` moves. For P = 128 and
-///   T = 32 that is about 4.0 million moves to place 4096 coefficients.
+/// - **Time:** dominated by an in-place transpose of the P by T rectangle, where
+///   P is `num_phases` and T is `coefficients.len() / num_phases`. See
+///   `matrix_transpose_in_place` for its cost.
 /// - **Space:** O(1); no auxiliary storage.
 ///
 /// [`pack_prototype_taps`] is O(P·T) and is preferable whenever a second buffer

--- a/src/filters/fir/polyphase/fractional_delay.rs
+++ b/src/filters/fir/polyphase/fractional_delay.rs
@@ -35,10 +35,10 @@
 //! Steps 3 and 4 can share one buffer instead of two. Allocate the packed
 //! length, generate the dense kernel into `taps[..dense_len]`, then call
 //! [`pack_prototype_taps_in_place`](super::filter_bank::pack_prototype_taps_in_place)
-//! over the whole slice. That reorder is quadratic in the packed length rather
-//! than linear, so use the two-buffer route unless the second allocation is
-//! unacceptable. The subslice is required because the design helpers assert an
-//! exact prototype length.
+//! over the whole slice. That reorder costs more than the linear two-buffer
+//! route, so prefer two buffers unless the second allocation is unacceptable.
+//! The subslice is required because the design helpers assert an exact
+//! prototype length.
 //!
 //! Throughout, `d0` is the bulk group delay every branch shares, in input
 //! samples:

--- a/src/math.rs
+++ b/src/math.rs
@@ -89,9 +89,7 @@ pub(crate) fn matrix_transpose_padded<T: Clone>(
 
     output.fill(padding);
     for (src, value) in input.iter().enumerate() {
-        let x = src % width;
-        let y = src / width;
-        output[x * height + y] = value.clone();
+        output[transposed_index(src, width, height)] = value.clone();
     }
 }
 
@@ -100,13 +98,15 @@ pub(crate) fn matrix_transpose_padded<T: Clone>(
 /// The matrix has `height` rows and `width` columns, and `matrix.len()` must be
 /// `width * height`. Supports rectangular matrices, not just square ones.
 ///
-/// This uses a rotation-based in-place algorithm that avoids a full auxiliary
-/// matrix. It is not linear-time: for large matrices, prefer
-/// [`matrix_transpose`] when a separate output buffer is available.
+/// Follows the cycles of the transposition permutation, needing only a constant
+/// number of index variables and no recursion. Prefer [`matrix_transpose`] when a
+/// separate output buffer is available, since it is linear.
 ///
 /// # Complexity
 ///
-/// Performs `O(width^2 * height^2 / 4)` element moves.
+/// - **Time:** `O(N log N)` index steps for `N = width * height`, of which exactly
+///   `N - 2` are element moves.
+/// - **Space:** `O(1)`, regardless of `N`.
 ///
 /// # Panics
 ///
@@ -122,20 +122,56 @@ pub(crate) fn matrix_transpose_in_place<T>(matrix: &mut [T], width: usize, heigh
         "matrix_transpose_in_place: matrix length must equal width * height"
     );
 
-    // Each inner iteration rotates a window of `step` elements ending at `last`
-    // (exclusive). `step` starts at 1 and grows by `width - x - 1` per row,
-    // advancing the rotation boundary through the transposition permutation for
-    // column group `x`.
-    for x in 0..width {
-        let count_adjustment = width - x - 1;
-        let mut step = 1;
-        for y in 0..height {
-            let last = count - (y + x * height);
-            let first = last - step;
-            matrix[first..last].rotate_left(1);
-            step += count_adjustment;
+    // A single row or column is already its own transpose in row-major order.
+    if count < 3 || width == 1 || height == 1 {
+        return;
+    }
+
+    // Row and column loops keep both coordinates as counters, so `first` tracks
+    // `column * height + row` by adding `height` per column, with no division and
+    // no multiply. Only the walks below divide.
+    let mut start = 0;
+    for row in 0..height {
+        let mut first = row;
+        for _ in 0..width {
+            // Visit each cycle once via its smallest index: walking from `start`
+            // reaches something smaller unless `start` is itself the smallest.
+            // That costs `O(cycle length)` and needs no visited set. The first and
+            // last indices are fixed points and rotate nothing.
+            let mut probe = first;
+            while probe > start {
+                probe = transposed_index(probe, width, height);
+            }
+
+            if probe == start {
+                // Rotate the cycle by swapping against its representative. After
+                // k swaps, `start` holds the element belonging k + 1 steps along.
+                // `swap` needs no element temporary, so `T` stays unbounded.
+                let mut next = first;
+                while next != start {
+                    matrix.swap(start, next);
+                    next = transposed_index(next, width, height);
+                }
+            }
+
+            first += height;
+            start += 1;
         }
     }
+}
+
+/// Maps a linear index of a `height` by `width` row-major matrix to its position
+/// after transposition.
+///
+/// Index `i` denotes row `i / width` and column `i - row * width`, which lands at
+/// `column * height + row` once transposed. Subtracting rather than taking a
+/// remainder keeps this to a single division, and every intermediate is bounded
+/// by `width * height`, so this stays within `usize` on 32-bit targets.
+#[inline]
+fn transposed_index(i: usize, width: usize, height: usize) -> usize {
+    let row = i / width;
+    let column = i - row * width;
+    column * height + row
 }
 
 /// Kahan compensated summation accumulator.
@@ -447,6 +483,71 @@ mod tests {
             matrix_transpose_in_place(&mut actual, width, height);
 
             assert_eq!(actual, expected, "width={width} height={height}");
+        }
+    }
+
+    /// The cycle structure of the transposition permutation varies sharply with
+    /// the factorisation of `width * height - 1`, so correctness is checked over
+    /// every geometry in a range rather than a handful of samples.
+    #[test]
+    fn matrix_transpose_in_place_matches_out_of_place_exhaustively() {
+        for width in 1..=32_usize {
+            for height in 1..=32_usize {
+                let input: Vec<_> = (0..width * height).collect();
+                let mut expected = vec![0; width * height];
+                matrix_transpose(&mut expected, &input, width, height);
+
+                let mut actual = input.clone();
+                matrix_transpose_in_place(&mut actual, width, height);
+
+                assert_eq!(actual, expected, "width={width} height={height}");
+            }
+        }
+    }
+
+    /// Transposing twice must restore the original for any geometry.
+    #[test]
+    fn matrix_transpose_in_place_is_an_involution() {
+        for width in 1..=24_usize {
+            for height in 1..=24_usize {
+                let input: Vec<_> = (0..width * height).collect();
+                let mut round_trip = input.clone();
+                matrix_transpose_in_place(&mut round_trip, width, height);
+                // the transposed matrix is `width` rows of `height`
+                matrix_transpose_in_place(&mut round_trip, height, width);
+                assert_eq!(round_trip, input, "width={width} height={height}");
+            }
+        }
+    }
+
+    /// An extreme aspect ratio gives the permutation a very different cycle
+    /// structure from a square matrix, and maximises the index arithmetic, so it
+    /// is checked separately from the exhaustive small-geometry sweep.
+    #[test]
+    fn matrix_transpose_in_place_handles_extreme_aspect_ratio() {
+        let (width, height) = (65536_usize, 2_usize);
+        let input: Vec<_> = (0..width * height).collect();
+        let mut expected = vec![0; width * height];
+        matrix_transpose(&mut expected, &input, width, height);
+
+        let mut actual = input.clone();
+        matrix_transpose_in_place(&mut actual, width, height);
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn matrix_transpose_in_place_moves_every_element_exactly_once() {
+        // Exactly N - 2 swaps means each non-fixed position is written once.
+        // A duplicated or dropped element would show up as a changed multiset.
+        for (width, height) in [(7, 5), (5, 7), (8, 8), (13, 3), (2, 31)] {
+            let n = width * height;
+            let input: Vec<_> = (0..n).collect();
+            let mut actual = input.clone();
+            matrix_transpose_in_place(&mut actual, width, height);
+            let mut sorted = actual.clone();
+            sorted.sort_unstable();
+            assert_eq!(sorted, input, "width={width} height={height}");
         }
     }
 


### PR DESCRIPTION
`matrix_transpose_in_place` rotated a growing window, costing `N + width(width - 1) * height(height - 1) / 4` moves for `N = width * height`. Packing a 128-phase bank of 32 taps per phase moved 4.0 million elements to place 4096 coefficients.

Transposition is a permutation, so this now uses the cycle-leader technique: rotate each cycle once, moving every element exactly once. A cycle is entered only from its smallest index, found by walking forward and rejecting the candidate if anything smaller appears, so no visited set is needed and space stays `O(1)` with no recursion. Swapping against the leader needs no element temporary, so `T` gains no bounds.

The index mapping is chosen to keep the arithmetic 32-bit on 32-bit systems, which matters on embedded targets. Index `i` sits at row `i / width` and column `i - row * width`, landing at `column * height + row`: one division, every intermediate below `N`. The closed form `i * height % (N - 1)` would need a product near `N^2`, forcing `u64` and an `__aeabi_uldivmod` call on a path the leader search evaluates `O(N log N)` times. Nested row and column loops reduce each position's own mapping to a single addition, leaving division to the cycle walks alone. Generated `thumbv7em-none-eabihf` code is `udiv`, `mls` and `mla`, with no libcall outside the panic paths. `matrix_transpose_padded` shares the same helper.

Fastest of nine runs, x86-64, `u32` elements, buffer refill subtracted:
```
    geometry      N     rotation      cycles    gain
     8x32       256       1.62us      0.86us    1.9x
    32x32      1024      10.82us      1.25us    8.7x
   128x32      4096     121.81us     20.26us    6.0x
   128x52      6656     303.74us    161.82us    1.9x
   256x64     16384    1886.87us     56.89us   33.2x
```
Gains trail the move-count ratio because `rotate_left` is a sequential `memmove` while cycle following swaps scattered elements and pays for the leader search, which peaks near `1.25 * N * log2(N)` steps. Verified against the out-of-place transpose for every geometry to 32x32, by round-tripping, by confirming the result is a permutation, and at an extreme aspect ratio.