### PR TITLE
Fix broken intra-doc links

### DIFF
--- a/src/filters/fir/convolve/differentiator.rs
+++ b/src/filters/fir/convolve/differentiator.rs
@@ -42,17 +42,18 @@
 //!
 //! # Related
 //!
-//! - [`Differentiate`](crate::filters::differentiate::Differentiate) for
+//! - [`Differentiate`](crate::filters::fir::differentiate::Differentiate) for
 //!   the O(1)-state two-tap backward difference (`h = [-1, 1]`).
-//! - `laplacian()` and `second_central_difference()` for the second
-//!   derivative.
-//! - [`savitzky_golay`](super::savitzky_golay) for Savitzky-Golay polynomial
+//! - [`laplacian()`](super::Convolve::laplacian) and
+//!   [`second_central_difference()`](super::Convolve::second_central_difference)
+//!   for the second derivative.
+//! - [`savitzky_golay`](crate::filters::fir::savitzky_golay) for Savitzky-Golay polynomial
 //!   smoothing.
 //!
 //! # Coefficient ordering
 //!
 //! `h[0]` pairs with the newest sample (see
-//! [`ConvolveArray::filter`](super::ConvolveArray::filter)).
+//! [`Convolve`'s coefficient ordering](super::Convolve#coefficient-ordering)).
 
 use crate::traits::WithConfig;
 

--- a/src/filters/fir/convolve/lagrange.rs
+++ b/src/filters/fir/convolve/lagrange.rs
@@ -34,7 +34,7 @@
 //!
 //! # Related
 //!
-//! - [`crate::filters::delay::Delay`] for integer delay.
+//! - [`crate::filters::util::delay::Delay`] for integer delay.
 //! - [`crate::filters::fir::convolve::windowed_sinc`] for frequency-domain
 //!   fractional-delay alternatives via windowed-sinc resampling.
 //!
@@ -42,7 +42,7 @@
 //!
 //! `half_sample_delay()` is pre-defined for even `M ∈ {4, 6, 8, 10}`. Odd `M`
 //! yields `(M−1)/2 ∈ ℤ` — that is an *integer* delay and should use
-//! [`Delay`](crate::filters::delay::Delay) (or
+//! [`Delay`](crate::filters::util::delay::Delay) (or
 //! [`ConvolveArray::with_config`](crate::filters::fir::convolve::ConvolveArray::with_config)
 //! with a unit impulse at the relevant tap).
 //!

--- a/src/filters/fir/convolve/moving_sum.rs
+++ b/src/filters/fir/convolve/moving_sum.rs
@@ -7,9 +7,9 @@
 //! A `MovingSum` is a bounded sliding sum over `N` samples:
 //! `y[n] = Σ_{k=0}^{N-1} x[n-k]`.
 //!
-//! This is distinct from [`Integrate`](crate::filters::integrate::Integrate),
+//! This is distinct from [`Integrate`](crate::filters::iir::integrate::Integrate),
 //! which is an IIR running sum (`y[n] = y[n-1] + x[n]`) with unbounded growth.
-//! For a bounded sliding average, use [`Mean`](crate::filters::mean::mean::Mean),
+//! For a bounded sliding average, use [`Mean`](crate::filters::fir::mean::Mean),
 //! which is essentially `MovingSum / N`.
 //!
 //! | Operator    | Formula                    | State | Boundedness             |

--- a/src/filters/fir/convolve/windowed_sinc.rs
+++ b/src/filters/fir/convolve/windowed_sinc.rs
@@ -45,7 +45,7 @@
 //!
 //! # Related
 //!
-//! - [`super::savitzky_golay`] for polynomial smoothing filters
+//! - [`crate::filters::fir::savitzky_golay`] for polynomial smoothing filters
 //! - [`super::ConvolveArray::normalized`] for general coefficient normalisation
 //!
 //! # Coefficient ordering
@@ -209,7 +209,7 @@ impl<T: Float + core::fmt::Debug, const N: usize> KaiserSinc<ConvolveArray<T, N>
     ///
     /// A larger β produces stronger stopband attenuation and a wider transition band.
     /// Typical values: 5.0–8.0 for general-purpose use (~50–70 dB attenuation).
-    /// Use [`Config::beta_for_attenuation`](crate::filters::window::kaiser::Config::beta_for_attenuation)
+    /// Use [`Config::beta_for_attenuation`](crate::filters::fir::window::kaiser::Config::beta_for_attenuation)
     /// to compute β from a desired stopband attenuation.
     ///
     /// # Panics

--- a/src/filters/rank/median.rs
+++ b/src/filters/rank/median.rs
@@ -157,8 +157,7 @@ pub type MedianVec<T> = Median<T, alloc::vec::Vec<ListNode<T>>>;
 ///
 /// This alias allows sharing a caller-owned node-buffer slice without taking
 /// ownership of it. Construct via [`Median::from_parts`], passing a
-/// correctly-linked `&mut [ListNode<T>]` slice (use [`MedianVec::new_buffer`]
-/// to build one).
+/// correctly-linked `&mut [ListNode<T>]` slice.
 pub type MedianRefMut<'a, T> = Median<T, &'a mut [ListNode<T>]>;
 
 impl<T, const N: usize> Default for MedianArray<T, N> {
@@ -368,8 +367,8 @@ where
     /// # Expected storage state
     ///
     /// For the idiomatic initial state, the buffer should contain correctly
-    /// linked nodes with all values set to `None`. Use
-    /// [`MedianVec::new_buffer`] to construct such a buffer.
+    /// linked nodes with all values set to `None`, so for a buffer of length
+    /// `n` that is `previous == (i + n - 1) % n` and `next == (i + 1) % n`.
     ///
     /// # Panics
     ///

--- a/src/filters/wavelet/analyze.rs
+++ b/src/filters/wavelet/analyze.rs
@@ -69,7 +69,8 @@ pub type AnalyzeArray<T, const N: usize> = Analyze<T, [T; N], FixedCircularBuffe
 #[cfg(feature = "alloc")]
 pub type AnalyzeVec<T> = Analyze<T, alloc::vec::Vec<T>, HeapCircularBuffer<T>>;
 
-/// A wavelet analysis filter that borrows a [`CircularBuffer`] tap buffer.
+/// A wavelet analysis filter that borrows a
+/// [`CircularBuffer`](circular_buffer::CircularBuffer) tap buffer.
 ///
 /// This alias allows sharing a caller-owned ring buffer without taking
 /// ownership of it. The coefficient storage `C` remains generic.

--- a/src/filters/wavelet/synthesize.rs
+++ b/src/filters/wavelet/synthesize.rs
@@ -68,7 +68,8 @@ pub type SynthesizeArray<T, const N: usize> = Synthesize<T, [T; N], FixedCircula
 #[cfg(feature = "alloc")]
 pub type SynthesizeVec<T> = Synthesize<T, alloc::vec::Vec<T>, HeapCircularBuffer<T>>;
 
-/// A wavelet synthesis filter that borrows a [`CircularBuffer`] tap buffer.
+/// A wavelet synthesis filter that borrows a
+/// [`CircularBuffer`](circular_buffer::CircularBuffer) tap buffer.
 ///
 /// This alias allows sharing a caller-owned ring buffer without taking
 /// ownership of it. The coefficient storage `C` remains generic.


### PR DESCRIPTION
`cargo doc --all-features` emitted 13 `broken_intra_doc_links` warnings. Most paths omitted the `fir`, `iir` or `util` layer that groups filters by kind.

`MedianVec::new_buffer` was referenced twice and never existed, so both links offered callers a way to build a `MedianRefMut` node buffer that they cannot follow. They now state the invariant instead: for length `n`, `previous` is `(i + n - 1) % n` and `next` is `(i + 1) % n`. `ListNode`'s fields are `pub(crate)`, so no public API can build such a buffer at all, which is a separate gap left alone here.