### PR TITLE
Add a complex `Mixer` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Please make sure to add your changes to the appropriate categories:
 - Added `Nco` phase-step conversion functions: `phase_step_from_turns_per_sample`, `phase_step_from_radians_per_sample`, `turns_per_sample_from_phase_step`, `radians_per_sample_from_phase_step`, `phase_word_from_turns`, `phase_word_from_radians`, `turns_from_phase_word`, and `radians_from_phase_word`
 - Added `Config::from_turns_per_sample` and `Config::from_radians_per_sample` constructors for creating NCO configs from turns-per-sample and radians-per-sample rates
 - Added `Nco::phasor_then_step` (behind `complex` feature), returning the current phasor and then advancing one sample — the correct order for derotating a stream
+- Added `math::phase::phasor_from_radians` (behind `complex` feature), converting an angle to a phase word and looking its phasor up in one call
+- Exposed `math::phase::MAX_ABS_ERROR`, the absolute-error bound of `sin`, `cos`, `sin_cos` and `phasor`, and documented that those are quarter-wave-table approximations rather than exact, so a caller can size a tolerance against the bound instead of copying a literal
+- Moved every phase-word, phase-step and frequency conversion from `Nco` to `math::phase` as free functions: `phase_word_from_turns`, `phase_word_from_radians`, `turns_from_phase_word`, `radians_from_phase_word`, `phase_step_from_turns_per_sample`, `phase_step_from_radians_per_sample`, `phase_step_from_frequency`, `turns_per_sample_from_phase_step`, `radians_per_sample_from_phase_step` and `frequency_from_phase_step`. `math::phase` owns the phase-word representation, and none of these involve the oscillator's scalar type, so calling them through `Nco` needed a turbofish for a type parameter they never used. The `Nco` associated functions remain and delegate, so existing callers are unaffected and agree bit for bit
 
 ### Changed
 

--- a/src/filters.rs
+++ b/src/filters.rs
@@ -18,6 +18,9 @@ pub mod fir;
 
 pub mod iir;
 
+#[cfg(feature = "complex")]
+pub mod mixer;
+
 pub mod ops;
 
 pub mod rank;

--- a/src/filters/mixer.rs
+++ b/src/filters/mixer.rs
@@ -1,0 +1,345 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+//! Complex mixing filter for frequency translation.
+//!
+//! A `Mixer` multiplies each input sample by a rotating phasor, shifting the
+//! signal's spectrum without altering its shape.
+//!
+//! Difference equation: `y[n] = x[n] · e^(j·θ[n])`
+//!
+//! where `θ[n]` is the driving oscillator's phase. The multiply is pointwise, so
+//! the filter has no delay and no transient. The operation is also called
+//! frequency translation, up- or downconversion, or rotation.
+//!
+//! # Use cases
+//!
+//! - Bringing a carrier offset to zero before demodulation.
+//! - Placing a baseband signal at an offset before transmission.
+//! - Centring a channel of interest before filtering it.
+//!
+//! # Related
+//!
+//! - [`crate::sources::oscillator::nco::Nco`] for the oscillator that drives the
+//!   phasor and sets the shift.
+//! - [`crate::filters::iir::loop_filter`] for the loop filter of a carrier
+//!   recovery loop that retunes the oscillator.
+//! - [`crate::filters::fir`] and [`crate::filters::iir`] for filters that shape
+//!   the spectrum rather than move it.
+
+use num_traits::float::FloatCore;
+
+use crate::complex::Complex;
+use crate::sources::oscillator::nco::{self, Nco};
+#[cfg(feature = "derive")]
+use crate::traits::ResetMut;
+use crate::traits::{
+    guts::{FromGuts, HasGuts, IntoGuts},
+    Config as ConfigTrait, ConfigClone, ConfigRef, Filter, Reset, State as StateTrait, StateMut,
+    WithConfig,
+};
+
+/// Multiplies each input sample by the driving oscillator's phasor, advancing the
+/// oscillator one step per sample.
+///
+/// # Sign convention
+///
+/// The phasor is `cos(phase) + j sin(phase)`, so mixing translates the input
+/// **up** in frequency by the oscillator's rate. Negate the rate to translate
+/// down, as removing a carrier offset requires:
+///
+/// ```
+/// # use signalo::filters::mixer::Mixer;
+/// # use signalo::sources::oscillator::nco::Nco;
+/// # use signalo::traits::Filter;
+/// # use signalo::complex::Complex32;
+/// // A tone at +0.05 cycles per sample, brought down to DC.
+/// let mut tone = Nco::<f32>::from_turns_per_sample(0.05);
+/// let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(-0.05));
+///
+/// for _ in 0..64 {
+///     let mixed = mixer.filter(tone.phasor_then_step());
+///     assert!((mixed.im).abs() < 1.0e-3);
+/// }
+/// ```
+///
+/// # Precision
+///
+/// `T` is the output type, not the working type. The phasor comes from [`Nco`],
+/// which interpolates an `f32` table, so `Mixer<f64>` widens `f32` values rather
+/// than refining them and is no more accurate than `Mixer<f32>`. See [`Nco`] for
+/// the bound.
+///
+/// # Complexity
+///
+/// - **Time per sample:** O(1); one phasor evaluation and one complex multiply.
+/// - **Space:** O(1); the oscillator's phase word and phase step.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Mixer<T = f32> {
+    nco: Nco<T>,
+}
+
+impl<T> Mixer<T> {
+    /// Creates a mixer driven by `nco`.
+    #[must_use]
+    pub const fn new(nco: Nco<T>) -> Self {
+        Self { nco }
+    }
+
+    /// Returns a reference to the driving oscillator.
+    #[must_use]
+    pub const fn nco(&self) -> &Nco<T> {
+        &self.nco
+    }
+
+    /// Returns a mutable reference to the driving oscillator.
+    ///
+    /// Retuning through this is how a feedback loop steers the mixer from an error
+    /// signal. A rate change leaves the accumulated phase untouched.
+    #[must_use]
+    pub const fn nco_mut(&mut self) -> &mut Nco<T> {
+        &mut self.nco
+    }
+}
+
+impl<T> ConfigTrait for Mixer<T> {
+    type Config = nco::Config<T>;
+}
+
+impl<T> StateTrait for Mixer<T> {
+    type State = nco::State<T>;
+}
+
+impl<T> WithConfig for Mixer<T>
+where
+    T: FloatCore + From<f32>,
+{
+    type Output = Self;
+
+    fn with_config(config: Self::Config) -> Self::Output {
+        Self {
+            nco: Nco::with_config(config),
+        }
+    }
+}
+
+impl<T> Default for Mixer<T>
+where
+    Nco<T>: Default,
+{
+    fn default() -> Self {
+        Self {
+            nco: Nco::default(),
+        }
+    }
+}
+
+impl<T> ConfigRef for Mixer<T> {
+    fn config_ref(&self) -> &Self::Config {
+        self.nco.config_ref()
+    }
+}
+
+impl<T> ConfigClone for Mixer<T>
+where
+    nco::Config<T>: Clone,
+{
+    fn config(&self) -> Self::Config {
+        self.nco.config()
+    }
+}
+
+impl<T> StateMut for Mixer<T> {
+    #[doc(hidden)]
+    fn state_mut(&mut self) -> &mut Self::State {
+        self.nco.state_mut()
+    }
+}
+
+impl<T> HasGuts for Mixer<T> {
+    type Guts = Nco<T>;
+}
+
+impl<T> FromGuts for Mixer<T> {
+    fn from_guts(guts: Self::Guts) -> Self {
+        Self { nco: guts }
+    }
+}
+
+impl<T> IntoGuts for Mixer<T> {
+    fn into_guts(self) -> Self::Guts {
+        self.nco
+    }
+}
+
+impl<T> Reset for Mixer<T>
+where
+    T: FloatCore + From<f32>,
+{
+    fn reset(self) -> Self {
+        Self {
+            nco: self.nco.reset(),
+        }
+    }
+}
+
+#[cfg(feature = "derive")]
+impl<T> ResetMut for Mixer<T> where Self: Reset {}
+
+impl<T> Filter<Complex<T>> for Mixer<T>
+where
+    T: FloatCore + From<f32>,
+{
+    type Output = Complex<T>;
+
+    fn filter(&mut self, input: Complex<T>) -> Self::Output {
+        input * self.nco.phasor_then_step()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use approx::assert_abs_diff_eq;
+
+    use super::*;
+    use crate::complex::Complex32;
+
+    // A mixed sample is a product of two table lookups, and the round-trip tests below chain two
+    // mixers, so four lookups contribute. Derived from the table's own bound rather than measured,
+    // so it tracks a change to the table's resolution.
+    const EPS: f32 = 4.0 * crate::math::phase::MAX_ABS_ERROR as f32;
+
+    #[test]
+    fn mixing_by_the_negated_rate_brings_a_tone_to_dc() {
+        let rate = 0.05_f32;
+        let mut tone = Nco::<f32>::from_turns_per_sample(rate);
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(-rate));
+
+        for _ in 0..256 {
+            let mixed = mixer.filter(tone.phasor_then_step());
+            assert_abs_diff_eq!(mixed.re, 1.0, epsilon = EPS);
+            assert_abs_diff_eq!(mixed.im, 0.0, epsilon = EPS);
+        }
+    }
+
+    #[test]
+    fn mixing_up_then_down_restores_the_input() {
+        let rate = 0.017_f32;
+        let mut up = Mixer::new(Nco::<f32>::from_turns_per_sample(rate));
+        let mut down = Mixer::new(Nco::<f32>::from_turns_per_sample(-rate));
+
+        for n in 0..256 {
+            let input = Complex32::new(n as f32 * 0.01 - 1.0, 0.5 - n as f32 * 0.003);
+            let round_tripped = down.filter(up.filter(input));
+            assert_abs_diff_eq!(round_tripped.re, input.re, epsilon = EPS);
+            assert_abs_diff_eq!(round_tripped.im, input.im, epsilon = EPS);
+        }
+    }
+
+    #[test]
+    fn mixing_shifts_upward_not_downward() {
+        // A tone at +rate mixed with +rate must land at 2 * rate, not at DC. Catches a conjugated
+        // phasor, which would look correct to a round-trip test.
+        let rate = 0.05_f32;
+        let mut tone = Nco::<f32>::from_turns_per_sample(rate);
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(rate));
+        let mut expected = Nco::<f32>::from_turns_per_sample(2.0 * rate);
+
+        for _ in 0..64 {
+            let mixed = mixer.filter(tone.phasor_then_step());
+            let want = expected.phasor_then_step();
+            assert_abs_diff_eq!(mixed.re, want.re, epsilon = EPS);
+            assert_abs_diff_eq!(mixed.im, want.im, epsilon = EPS);
+        }
+    }
+
+    #[test]
+    fn the_oscillator_advances_one_step_per_sample() {
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(0.013));
+        let mut reference = Nco::<f32>::from_turns_per_sample(0.013);
+
+        for _ in 0..32 {
+            let _ = mixer.filter(Complex32::new(1.0, 0.0));
+            reference.step();
+            assert_eq!(mixer.nco().phase(), reference.phase());
+        }
+    }
+
+    #[test]
+    fn retuning_through_nco_mut_leaves_the_phase_alone() {
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(0.1));
+        for _ in 0..4 {
+            let _ = mixer.filter(Complex32::new(1.0, 0.0));
+        }
+
+        let phase = mixer.nco().phase();
+        mixer.nco_mut().set_turns_per_sample(-0.2);
+
+        assert_eq!(mixer.nco().phase(), phase);
+        assert_eq!(
+            mixer.nco().phase_step(),
+            Nco::<f32>::phase_step_from_turns_per_sample(-0.2)
+        );
+    }
+
+    #[test]
+    fn reset_rewinds_the_phase_but_keeps_the_rate() {
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(0.1));
+        for _ in 0..8 {
+            let _ = mixer.filter(Complex32::new(1.0, 0.0));
+        }
+        assert_ne!(mixer.nco().phase(), 0);
+
+        let step = mixer.nco().phase_step();
+        let mixer = mixer.reset();
+
+        assert_eq!(mixer.nco().phase(), 0);
+        assert_eq!(mixer.nco().phase_step(), step);
+    }
+
+    #[test]
+    fn with_config_round_trips_through_config_ref() {
+        let config = *Nco::<f32>::from_turns_per_sample(0.125).config_ref();
+        let mixer = Mixer::<f32>::with_config(config);
+
+        assert_eq!(*mixer.config_ref(), config);
+        assert_eq!(mixer.config(), config);
+        assert_eq!(mixer.nco().phase(), 0);
+    }
+
+    #[test]
+    fn guts_round_trip_preserves_the_oscillator() {
+        let mut mixer = Mixer::new(Nco::<f32>::from_turns_per_sample(0.05));
+        let _ = mixer.filter(Complex32::new(1.0, 0.0));
+
+        let expected = mixer.clone();
+        let rebuilt = Mixer::from_guts(mixer.into_guts());
+
+        assert_eq!(rebuilt, expected);
+    }
+
+    #[test]
+    fn equal_mixers_compare_equal_and_diverge_once_stepped() {
+        let mut a = Mixer::new(Nco::<f32>::from_turns_per_sample(0.05));
+        let b = a.clone();
+        assert_eq!(a, b);
+
+        let _ = a.filter(Complex32::new(1.0, 0.0));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn a_zero_rate_mixer_is_the_identity() {
+        let mut mixer = Mixer::<f32>::default();
+
+        // Away from zero, because a complex multiply forms `im = re * 0 + im * 1`, which turns a
+        // negative zero positive. That is a property of the multiply, not of the mixer.
+        for n in 1..16 {
+            let input = Complex32::new(n as f32, -(n as f32));
+            let output = mixer.filter(input);
+            assert_eq!(output.re.to_bits(), input.re.to_bits());
+            assert_eq!(output.im.to_bits(), input.im.to_bits());
+        }
+    }
+}

--- a/src/math/phase.rs
+++ b/src/math/phase.rs
@@ -14,6 +14,31 @@
 //!
 //! The represented interval is `[0, 1)` turns. Wrapping arithmetic on the phase
 //! word naturally wraps the oscillator phase.
+//!
+//! Values come from a quarter-wave sine table with linear interpolation
+//! between entries, so they are approximations: [`MAX_ABS_ERROR`] bounds the
+//! absolute error at about `4.8e-6`, where `libm`'s `sinf` and `cosf` are
+//! accurate to near an `f32` ULP. In exchange there is no transcendental call,
+//! which is the point on a target where that call is expensive.
+//!
+//! A companion `i32` phase step is the same scale read as a signed rate, one
+//! step being the phase advanced per sample, folded into `[-1 / 2, 1 / 2)`
+//! turns per sample. Turns are the phase word's own unit, so every other
+//! spelling of a phase or a rate converts through the turns functions here,
+//! including a rate in Hz, which divides by a sample rate to reach turns per
+//! sample.
+
+use num_traits::float::FloatCore;
+
+/// Phase words in one full turn, which is the scale between turns and a phase word or step.
+///
+/// Deliberately `f32` rather than an integer phase word like [`QUARTER_TURN`]: a full turn is `2^32`,
+/// which does not fit in `u32`, and this is only ever a float scale to multiply or divide by. It is
+/// exact, `2^32` being a power of two well inside `f32`'s range, so scaling by it never rounds.
+/// One turn spans the whole phase word, so `2^32` words. Exactly representable in
+/// `f32`, the cast rounds nothing.
+#[allow(clippy::cast_precision_loss)]
+const PHASE_WORDS_PER_TURN: f32 = (1_u64 << u32::BITS) as f32;
 
 const QUARTER_TURN: u32 = 0x4000_0000;
 const QUARTER_BITS: u32 = 8;
@@ -22,6 +47,24 @@ const FRAC_BITS: u32 = 30 - QUARTER_BITS;
 const FRAC_MASK: u32 = (1_u32 << FRAC_BITS) - 1;
 #[allow(clippy::cast_precision_loss)]
 const FRAC_SCALE_RECIP: f32 = 1.0 / ((1_u32 << FRAC_BITS) as f32);
+
+/// Upper bound on the absolute error of [`sin`], [`cos`], [`sin_cos`] and [`phasor`].
+///
+/// About `4.8e-6`. Exposed so a caller choosing between these and a true
+/// `sin`/`cos` can size a tolerance against the bound rather than a copied
+/// literal.
+///
+/// `f64` although it bounds `f32` functions, because the bound is derived from
+/// the table geometry and rounding it to `f32` would lose that derivation. Cast
+/// at the point of use for an `f32` tolerance.
+pub const MAX_ABS_ERROR: f64 = {
+    const QUARTER_SEGMENTS: f64 = (1_u32 << QUARTER_BITS) as f64;
+    const SEGMENT_RADIANS: f64 = core::f64::consts::FRAC_PI_2 / QUARTER_SEGMENTS;
+    // Linear interpolation error is bounded by max(|f''(x)|) * h^2 / 8.
+    // For sin(x), max(|f''(x)|) <= 1, so the table's segment width h gives
+    // h^2 / 8. Add one f32 epsilon for table quantization/arithmetic margin.
+    (SEGMENT_RADIANS * SEGMENT_RADIANS / 8.0) + (f32::EPSILON as f64)
+};
 
 /// Computes sine for a 32-bit wrapping phase word.
 ///
@@ -58,6 +101,180 @@ pub fn sin_cos(phase: u32) -> (f32, f32) {
 pub fn phasor(phase: u32) -> crate::complex::Complex32 {
     let (imag, real) = sin_cos(phase);
     crate::complex::Complex32::new(real, imag)
+}
+
+/// Computes the complex phasor for a phase in radians.
+///
+/// This is [`phase_word_from_radians`] followed by [`phasor`], which is the common pairing when the
+/// caller holds an angle rather than a phase word. It replaces a `sin`/`cos` pair with a table lookup,
+/// so it trades [`MAX_ABS_ERROR`] of accuracy for having no transcendental call to make.
+///
+/// # Panics
+///
+/// Panics if `radians` is not finite.
+#[cfg(feature = "complex")]
+#[must_use]
+#[inline]
+pub fn phasor_from_radians(radians: f32) -> crate::complex::Complex32 {
+    phasor(phase_word_from_radians(radians))
+}
+
+/// Converts a phase in turns to a wrapping full-turn phase word.
+///
+/// # Panics
+///
+/// Panics if `turns` is not finite.
+#[must_use]
+pub fn phase_word_from_turns(turns: f32) -> u32 {
+    assert!(turns.is_finite(), "phase: turns must be finite");
+    // Folding through the signed step keeps a small negative phase small, which folding through
+    // `[0, 1)` turns would not: at `f32` precision a tiny negative value becomes exactly one turn.
+    phase_step_from_turns_per_sample(turns).cast_unsigned()
+}
+
+/// Converts a phase in radians to a wrapping full-turn phase word.
+///
+/// One turn is `2π` radians, so any finite input folds into the single turn the phase word
+/// represents.
+///
+/// # Panics
+///
+/// Panics if `radians` is not finite.
+#[must_use]
+pub fn phase_word_from_radians(radians: f32) -> u32 {
+    assert!(radians.is_finite(), "phase: radians must be finite");
+    phase_word_from_turns(radians / core::f32::consts::TAU)
+}
+
+/// Converts a wrapping full-turn phase word to turns in `[0, 1)`.
+///
+/// The unsigned counterpart of [`turns_per_sample_from_phase_step`], and the only other place the
+/// phase-word scale is applied.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn turns_from_phase_word(phase: u32) -> f32 {
+    phase as f32 / PHASE_WORDS_PER_TURN
+}
+
+/// Converts a wrapping full-turn phase word to radians in `[0, 2π)`.
+#[must_use]
+pub fn radians_from_phase_word(phase: u32) -> f32 {
+    turns_from_phase_word(phase) * core::f32::consts::TAU
+}
+
+/// Converts turns per sample to a signed phase step.
+///
+/// This is where the conversion actually happens. Turns per sample is the phase word's own unit, one
+/// turn being its full range, so every other spelling of a frequency reduces to this one:
+/// [`phase_step_from_frequency`] divides by the sample rate first and
+/// [`phase_step_from_radians_per_sample`] divides by `2π`. Rates outside the Nyquist interval of
+/// half a turn per sample fold and alias.
+///
+/// # Panics
+///
+/// Panics if `turns_per_sample` is not finite.
+#[must_use]
+pub fn phase_step_from_turns_per_sample(turns_per_sample: f32) -> i32 {
+    assert!(
+        turns_per_sample.is_finite(),
+        "phase: turns per sample must be finite"
+    );
+
+    phase_step_from_turns_per_sample_unchecked(turns_per_sample)
+}
+
+/// Folds and scales turns per sample without checking it.
+///
+/// Split out so each public entry point keeps its own documented panic contract.
+/// [`phase_step_from_frequency`] accepts finite inputs whose ratio overflows, and folding an infinite
+/// rate yields `NaN`, which casts to a step of zero.
+#[allow(clippy::cast_possible_truncation)]
+fn phase_step_from_turns_per_sample_unchecked(turns_per_sample: f32) -> i32 {
+    let folded = turns_per_sample - FloatCore::floor(turns_per_sample + 0.5);
+    // Truncated towards zero, which is what [`phase_step_from_frequency`] has always done. Every
+    // spelling of a rate reduces to this one, so they all agree exactly.
+    FloatCore::trunc(folded * PHASE_WORDS_PER_TURN) as i32
+}
+
+/// Converts radians per sample to a signed phase step.
+///
+/// Rates outside the Nyquist interval of `π` radians per sample fold modulo `2π` and alias, as with
+/// [`phase_step_from_frequency`].
+///
+/// # Panics
+///
+/// Panics if `radians_per_sample` is not finite.
+#[must_use]
+pub fn phase_step_from_radians_per_sample(radians_per_sample: f32) -> i32 {
+    phase_step_from_turns_per_sample(radians_per_sample / core::f32::consts::TAU)
+}
+
+/// Converts a signed phase step to turns per sample.
+///
+/// The inverse counterpart, and likewise the one place the scale is applied.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn turns_per_sample_from_phase_step(phase_step: i32) -> f32 {
+    phase_step as f32 / PHASE_WORDS_PER_TURN
+}
+
+/// Converts a signed phase step to radians per sample.
+#[must_use]
+pub fn radians_per_sample_from_phase_step(phase_step: i32) -> f32 {
+    turns_per_sample_from_phase_step(phase_step) * core::f32::consts::TAU
+}
+
+/// Converts a frequency and sample rate in Hz to a signed phase step.
+///
+/// The returned step represents `frequency_hz / sample_rate_hz` turns per sample, folded into
+/// `[-1 / 2, 1 / 2)` turns per sample. Frequencies outside the Nyquist interval of `sample_rate_hz`
+/// therefore alias to the folded frequency.
+///
+/// # Panics
+///
+/// Panics if either input is not finite or `sample_rate_hz <= 0`.
+///
+/// A finite pair whose ratio overflows does not panic. `is_finite` on the
+/// arguments does not imply a finite ratio, and folding an infinite rate yields
+/// `NaN`, which casts to a step of zero. Routing this through
+/// [`phase_step_from_turns_per_sample`] instead would panic there, so the
+/// unchecked fold is deliberate rather than an oversight.
+#[must_use]
+pub fn phase_step_from_frequency(frequency_hz: f32, sample_rate_hz: f32) -> i32 {
+    assert!(frequency_hz.is_finite(), "phase: frequency must be finite");
+    assert!(
+        sample_rate_hz.is_finite(),
+        "phase: sample rate must be finite"
+    );
+    assert!(sample_rate_hz > 0.0, "phase: sample rate must be > 0");
+
+    // Deliberately the unchecked form: a finite pair whose ratio overflows must keep returning zero
+    // rather than start panicking.
+    phase_step_from_turns_per_sample_unchecked(frequency_hz / sample_rate_hz)
+}
+
+/// Converts a signed phase step to frequency in Hz.
+///
+/// # Panics
+///
+/// Panics if `sample_rate_hz` is not finite or `sample_rate_hz <= 0`.
+///
+/// A large step against a large rate returns an infinity rather than panicking,
+/// because the product forms before the scale divides it. That expression order
+/// is deliberate, so reassociating it would change the result.
+#[must_use]
+#[allow(clippy::cast_precision_loss)]
+pub fn frequency_from_phase_step(phase_step: i32, sample_rate_hz: f32) -> f32 {
+    assert!(
+        sample_rate_hz.is_finite(),
+        "phase: sample rate must be finite"
+    );
+    assert!(sample_rate_hz > 0.0, "phase: sample rate must be > 0");
+
+    // Deliberately not `turns_per_sample_from_phase_step(phase_step) * sample_rate_hz`. Dividing by
+    // the scale first is bit-exact wherever this order does not overflow, but it returns a finite
+    // value where this one reaches infinity, which would change behaviour.
+    phase_step as f32 * sample_rate_hz / PHASE_WORDS_PER_TURN
 }
 
 #[inline]
@@ -177,13 +394,6 @@ mod tests {
 
     const EPS: f32 = 1.0e-6;
     const FULL_TURN_PHASE_WORDS: f64 = (u32::MAX as f64) + 1.0;
-    const QUARTER_SEGMENTS: f64 = (1_u32 << QUARTER_BITS) as f64;
-    const SEGMENT_RADIANS: f64 = core::f64::consts::FRAC_PI_2 / QUARTER_SEGMENTS;
-    // Linear interpolation error is bounded by max(|f''(x)|) * h^2 / 8.
-    // For sin(x), max(|f''(x)|) <= 1, so the table's segment width h gives
-    // h^2 / 8. Add one f32 epsilon for table quantization/arithmetic margin.
-    const MAX_INTERPOLATION_ERROR: f64 =
-        (SEGMENT_RADIANS * SEGMENT_RADIANS / 8.0) + (f32::EPSILON as f64);
     const PRE_WRAP_EPS: f64 = 1.0e-12;
 
     #[test]
@@ -250,12 +460,12 @@ mod tests {
             assert_abs_diff_eq!(
                 f64::from(sin(phase)),
                 radians.sin(),
-                epsilon = MAX_INTERPOLATION_ERROR
+                epsilon = MAX_ABS_ERROR
             );
             assert_abs_diff_eq!(
                 f64::from(cos(phase)),
                 radians.cos(),
-                epsilon = MAX_INTERPOLATION_ERROR
+                epsilon = MAX_ABS_ERROR
             );
         }
     }
@@ -268,5 +478,150 @@ mod tests {
 
         assert_abs_diff_eq!(phasor.re, cos(phase), epsilon = EPS);
         assert_abs_diff_eq!(phasor.im, sin(phase), epsilon = EPS);
+    }
+
+    /// The radians pairing agrees exactly with converting and looking up separately, and lands on the
+    /// cardinal phases.
+    #[test]
+    #[cfg(feature = "complex")]
+    fn phasor_from_radians_matches_the_two_step_form() {
+        use core::f32::consts::TAU;
+
+        for turns in [0.0_f32, 0.125, 0.25, 0.5, 0.75, -0.25, 1.5] {
+            let radians = turns * TAU;
+            assert_eq!(
+                phasor_from_radians(radians),
+                phasor(phase_word_from_radians(radians)),
+                "turns {turns}"
+            );
+        }
+        assert_abs_diff_eq!(phasor_from_radians(0.0).re, 1.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(phasor_from_radians(0.0).im, 0.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(phasor_from_radians(TAU / 4.0).re, 0.0, epsilon = 1e-6);
+        assert_abs_diff_eq!(phasor_from_radians(TAU / 4.0).im, 1.0, epsilon = 1e-6);
+    }
+
+    /// Every conversion the oscillator exposes delegates here, so the two spellings must be the same
+    /// bits, not merely close.
+    #[test]
+    fn frequency_helpers_convert_hz_and_phase_step() {
+        let step = phase_step_from_frequency(250.0, 1000.0);
+        assert_eq!(step, 0x4000_0000);
+
+        let negative_step = phase_step_from_frequency(-250.0, 1000.0);
+        assert_eq!(negative_step, -0x4000_0000);
+
+        assert_abs_diff_eq!(
+            frequency_from_phase_step(step, 1000.0),
+            250.0,
+            epsilon = EPS
+        );
+    }
+
+    #[test]
+    fn phase_step_from_frequency_truncates_towards_zero() {
+        // 7.3 / 48000 is 653192.53 phase words. Pinned because delegating to the turns helper must
+        // not change what this has always returned.
+        assert_eq!(phase_step_from_frequency(7.3, 48_000.0), 653_192);
+        assert_eq!(phase_step_from_frequency(-7.3, 48_000.0), -653_192);
+        assert_eq!(phase_step_from_frequency(250.0, 1000.0), 0x4000_0000);
+        // Both inputs are finite but their ratio overflows, which folds to `NaN` and casts to zero.
+        // Pinned because routing this through the checked helper would panic instead, and the
+        // documented contract promises a panic only for a non-finite input.
+        assert_eq!(phase_step_from_frequency(3.0e38, 1.0e-38), 0);
+    }
+
+    #[test]
+    fn frequency_from_phase_step_keeps_the_product_order() {
+        // The product forms before the scale divides it, so a large step against a large sample rate
+        // reaches infinity. Pinned so the expression is not reassociated: dividing by the scale first
+        // would return a finite value here and silently change what this has always returned.
+        assert!(frequency_from_phase_step(i32::MAX, 1.0e30).is_infinite());
+        assert_abs_diff_eq!(
+            frequency_from_phase_step(0x4000_0000, 1000.0),
+            250.0,
+            epsilon = EPS
+        );
+    }
+
+    #[test]
+    fn frequency_and_turns_spellings_agree_on_the_same_rate() {
+        // Ratios that are not whole fractions of a turn, so the two paths would diverge if either
+        // folded or truncated differently.
+        for &(frequency_hz, sample_rate_hz) in
+            &[(7.3_f32, 48_000.0_f32), (-7.3, 48_000.0), (1.0, 7.0)]
+        {
+            assert_eq!(
+                phase_step_from_frequency(frequency_hz, sample_rate_hz),
+                phase_step_from_turns_per_sample(frequency_hz / sample_rate_hz)
+            );
+        }
+    }
+
+    #[test]
+    fn nyquist_frequency_folds_to_negative_nyquist() {
+        assert_eq!(phase_step_from_frequency(500.0, 1000.0), i32::MIN);
+        assert_eq!(phase_step_from_frequency(-500.0, 1000.0), i32::MIN);
+    }
+
+    #[test]
+    fn frequency_aliases_fold_modulo_sample_rate() {
+        assert_eq!(phase_step_from_frequency(750.0, 1000.0), -0x4000_0000);
+        assert_eq!(phase_step_from_frequency(-750.0, 1000.0), 0x4000_0000);
+    }
+
+    #[test]
+    fn turns_and_radians_agree_on_the_same_rotation() {
+        let turns = 0.1_f32;
+
+        assert_eq!(
+            phase_step_from_turns_per_sample(turns),
+            phase_step_from_radians_per_sample(turns * core::f32::consts::TAU)
+        );
+    }
+
+    #[test]
+    fn turn_helpers_convert_whole_fractions_of_a_turn() {
+        // A whole fraction of a turn is a whole number of phase words, so these are exact.
+        assert_eq!(phase_step_from_turns_per_sample(0.25), 0x4000_0000);
+        assert_eq!(phase_step_from_turns_per_sample(-0.25), -0x4000_0000);
+        assert_eq!(phase_word_from_turns(-0.25), 0xC000_0000);
+        // Three quarters of a turn per sample aliases to a quarter turn backwards.
+        assert_eq!(phase_step_from_turns_per_sample(0.75), -0x4000_0000);
+
+        assert_abs_diff_eq!(
+            turns_per_sample_from_phase_step(0x4000_0000),
+            0.25,
+            epsilon = EPS
+        );
+    }
+
+    #[test]
+    fn radian_helpers_convert_whole_fractions_of_a_turn() {
+        use core::f32::consts::TAU;
+
+        // A whole fraction of a turn is a whole number of phase words, so these are exact.
+        assert_eq!(phase_step_from_radians_per_sample(TAU / 4.0), 0x4000_0000);
+        assert_eq!(phase_step_from_radians_per_sample(-TAU / 4.0), -0x4000_0000);
+        assert_eq!(phase_step_from_radians_per_sample(TAU / 8.0), 0x2000_0000);
+        assert_eq!(phase_word_from_radians(TAU / 4.0), 0x4000_0000);
+        assert_eq!(phase_word_from_radians(-TAU / 4.0), 0xC000_0000);
+
+        // Three quarters of a turn per sample aliases to a quarter turn backwards.
+        assert_eq!(
+            phase_step_from_radians_per_sample(3.0 * TAU / 4.0),
+            -0x4000_0000
+        );
+
+        assert_abs_diff_eq!(
+            radians_per_sample_from_phase_step(0x4000_0000),
+            TAU / 4.0,
+            epsilon = EPS
+        );
+        assert_abs_diff_eq!(
+            radians_from_phase_word(0xC000_0000),
+            3.0 * TAU / 4.0,
+            epsilon = EPS
+        );
     }
 }

--- a/src/sources/oscillator/nco.rs
+++ b/src/sources/oscillator/nco.rs
@@ -152,7 +152,18 @@ impl<T> State<T> {
 ///
 /// - **Time per sample:** O(1); one wrapping addition and one lookup/approximation for sin/cos.
 /// - **Space:** O(1); stores one 32-bit phase word.
-#[derive(Clone, Debug)]
+///
+/// # Precision
+///
+/// `T` is the output type, not the working type. It appears only in the return
+/// position of [`Self::sin`], [`Self::cos`], [`Self::sin_cos`], [`Self::phasor`]
+/// and [`Self::phasor_then_step`], while every frequency and phase conversion is
+/// `f32` regardless of it.
+///
+/// Phase is an exact 32-bit word, but sine and cosine are approximations bounded
+/// by [`crate::math::phase::MAX_ABS_ERROR`], so `Nco<f64>` widens `f32` values
+/// rather than refining them and is no more accurate than `Nco<f32>`.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Nco<T = f32> {
     config: Config<T>,
     state: State<T>,

--- a/src/sources/oscillator/nco.rs
+++ b/src/sources/oscillator/nco.rs
@@ -9,15 +9,15 @@
 //! accumulator wraps naturally, while the signed step represents positive and
 //! negative rotation without requiring callers to manually encode two's
 //! complement values.
+//!
+//! Both are [`crate::math::phase`]'s representation, and every conversion into
+//! and out of them delegates there.
 
 use crate::math;
 use crate::traits::Source;
 
 use core::marker::PhantomData;
 use num_traits::float::FloatCore;
-
-#[allow(clippy::cast_precision_loss)]
-const HALF_TURN_PHASE_WORD: f32 = 0x8000_0000_u32 as f32;
 
 /// NCO configuration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -375,10 +375,7 @@ impl<T> Nco<T> {
     /// Panics if `turns` is not finite.
     #[must_use]
     pub fn phase_word_from_turns(turns: f32) -> u32 {
-        assert!(turns.is_finite(), "nco: phase in turns must be finite");
-        // Folding through the signed step keeps a small negative phase small, which folding through
-        // `[0, 1)` turns would not: at `f32` precision a tiny negative value becomes exactly one turn.
-        Self::phase_step_from_turns_per_sample(turns).cast_unsigned()
+        math::phase::phase_word_from_turns(turns)
     }
 
     /// Converts turns per sample to a signed phase step.
@@ -386,7 +383,7 @@ impl<T> Nco<T> {
     /// This is where the conversion actually happens. Turns per sample is the phase word's own unit,
     /// one turn being its full range, so every other spelling of a frequency reduces to this one:
     /// [`Self::phase_step_from_frequency`] divides by the sample rate first and
-    /// [`Self::phase_step_from_radians_per_sample`] divides by `2 pi`. Rates outside the Nyquist interval of
+    /// [`Self::phase_step_from_radians_per_sample`] divides by `2π`. Rates outside the Nyquist interval of
     /// half a turn per sample fold and alias.
     ///
     /// # Panics
@@ -395,25 +392,7 @@ impl<T> Nco<T> {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn phase_step_from_turns_per_sample(turns_per_sample: f32) -> i32 {
-        assert!(
-            turns_per_sample.is_finite(),
-            "nco: turns per sample must be finite"
-        );
-
-        Self::phase_step_from_turns_per_sample_unchecked(turns_per_sample)
-    }
-
-    /// Folds and scales turns per sample without checking it.
-    ///
-    /// Split out so each public entry point keeps its own documented panic contract.
-    /// [`Self::phase_step_from_frequency`] accepts finite inputs whose ratio overflows, and folding
-    /// an infinite rate yields `NaN`, which casts to a step of zero.
-    #[allow(clippy::cast_possible_truncation)]
-    fn phase_step_from_turns_per_sample_unchecked(turns_per_sample: f32) -> i32 {
-        let folded = turns_per_sample - (turns_per_sample + 0.5).floor();
-        // Truncated towards zero, which is what [`Self::phase_step_from_frequency`] has always done.
-        // Every spelling of a rate reduces to this one, so they all agree exactly.
-        (folded * 2.0 * HALF_TURN_PHASE_WORD).trunc() as i32
+        math::phase::phase_step_from_turns_per_sample(turns_per_sample)
     }
 
     /// Converts a signed phase step to turns per sample.
@@ -422,12 +401,12 @@ impl<T> Nco<T> {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn turns_per_sample_from_phase_step(phase_step: i32) -> f32 {
-        phase_step as f32 / (2.0 * HALF_TURN_PHASE_WORD)
+        math::phase::turns_per_sample_from_phase_step(phase_step)
     }
 
     /// Creates an NCO from an initial phase and a phase step, both in radians.
     ///
-    /// Steps outside the Nyquist interval of `pi` radians per sample fold and alias, as with
+    /// Steps outside the Nyquist interval of `π` radians per sample fold and alias, as with
     /// [`Self::from_frequency`].
     ///
     /// # Panics
@@ -441,7 +420,7 @@ impl<T> Nco<T> {
         )
     }
 
-    /// Returns the phase step in radians per sample, folded into `[-pi, pi)`.
+    /// Returns the phase step in radians per sample, folded into `[-π, π)`.
     #[must_use]
     pub fn radians_per_sample(&self) -> f32 {
         Self::radians_per_sample_from_phase_step(self.config.phase_step)
@@ -453,7 +432,7 @@ impl<T> Nco<T> {
         Self::turns_from_phase_word(self.state.phase)
     }
 
-    /// Returns the current phase in radians, in `[0, 2 pi)`.
+    /// Returns the current phase in radians, in `[0, 2π)`.
     #[must_use]
     pub fn phase_radians(&self) -> f32 {
         Self::radians_from_phase_word(self.state.phase)
@@ -461,7 +440,7 @@ impl<T> Nco<T> {
 
     /// Converts a phase in radians to a wrapping full-turn phase word.
     ///
-    /// One turn is `2 pi` radians, so any finite input folds into the single turn the phase word
+    /// One turn is `2π` radians, so any finite input folds into the single turn the phase word
     /// represents.
     ///
     /// # Panics
@@ -469,13 +448,12 @@ impl<T> Nco<T> {
     /// Panics if `radians` is not finite.
     #[must_use]
     pub fn phase_word_from_radians(radians: f32) -> u32 {
-        assert!(radians.is_finite(), "nco: phase in radians must be finite");
-        Self::phase_word_from_turns(radians / core::f32::consts::TAU)
+        math::phase::phase_word_from_radians(radians)
     }
 
     /// Converts radians per sample to a signed phase step.
     ///
-    /// Rates outside the Nyquist interval of `pi` radians per sample fold modulo `2 pi` and
+    /// Rates outside the Nyquist interval of `π` radians per sample fold modulo `2π` and
     /// alias, as with [`Self::phase_step_from_frequency`].
     ///
     /// # Panics
@@ -483,19 +461,19 @@ impl<T> Nco<T> {
     /// Panics if `radians_per_sample` is not finite.
     #[must_use]
     pub fn phase_step_from_radians_per_sample(radians_per_sample: f32) -> i32 {
-        Self::phase_step_from_turns_per_sample(radians_per_sample / core::f32::consts::TAU)
+        math::phase::phase_step_from_radians_per_sample(radians_per_sample)
     }
 
     /// Converts a signed phase step to radians per sample.
     #[must_use]
     pub fn radians_per_sample_from_phase_step(phase_step: i32) -> f32 {
-        Self::turns_per_sample_from_phase_step(phase_step) * core::f32::consts::TAU
+        math::phase::radians_per_sample_from_phase_step(phase_step)
     }
 
-    /// Converts a wrapping full-turn phase word to radians in `[0, 2 pi)`.
+    /// Converts a wrapping full-turn phase word to radians in `[0, 2π)`.
     #[must_use]
     pub fn radians_from_phase_word(phase: u32) -> f32 {
-        Self::turns_from_phase_word(phase) * core::f32::consts::TAU
+        math::phase::radians_from_phase_word(phase)
     }
 
     /// Converts a wrapping full-turn phase word to turns in `[0, 1)`.
@@ -505,7 +483,7 @@ impl<T> Nco<T> {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn turns_from_phase_word(phase: u32) -> f32 {
-        phase as f32 / (2.0 * HALF_TURN_PHASE_WORD)
+        math::phase::turns_from_phase_word(phase)
     }
 
     /// Returns the phasor at the current phase, then advances one sample.
@@ -538,16 +516,7 @@ impl<T> Nco<T> {
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
     pub fn phase_step_from_frequency(frequency_hz: f32, sample_rate_hz: f32) -> i32 {
-        assert!(frequency_hz.is_finite(), "nco: frequency must be finite");
-        assert!(
-            sample_rate_hz.is_finite(),
-            "nco: sample rate must be finite"
-        );
-        assert!(sample_rate_hz > 0.0, "nco: sample rate must be > 0");
-
-        // Deliberately the unchecked form: a finite pair whose ratio overflows must keep returning
-        // zero rather than start panicking.
-        Self::phase_step_from_turns_per_sample_unchecked(frequency_hz / sample_rate_hz)
+        math::phase::phase_step_from_frequency(frequency_hz, sample_rate_hz)
     }
 
     /// Converts a signed phase step to frequency in Hz.
@@ -558,16 +527,7 @@ impl<T> Nco<T> {
     #[must_use]
     #[allow(clippy::cast_precision_loss)]
     pub fn frequency_from_phase_step(phase_step: i32, sample_rate_hz: f32) -> f32 {
-        assert!(
-            sample_rate_hz.is_finite(),
-            "nco: sample rate must be finite"
-        );
-        assert!(sample_rate_hz > 0.0, "nco: sample rate must be > 0");
-
-        // Deliberately not `turns_per_sample_from_phase_step(phase_step) * sample_rate_hz`.
-        // Dividing by the scale first is bit-exact wherever this order does not overflow, but it
-        // returns a finite value where this one reaches infinity, which would change behaviour.
-        phase_step as f32 * sample_rate_hz / (2.0 * HALF_TURN_PHASE_WORD)
+        math::phase::frequency_from_phase_step(phase_step, sample_rate_hz)
     }
 }
 
@@ -656,21 +616,6 @@ mod tests {
     }
 
     #[test]
-    fn frequency_helpers_convert_hz_and_phase_step() {
-        let step = Nco::<f32>::phase_step_from_frequency(250.0, 1000.0);
-        assert_eq!(step, 0x4000_0000);
-
-        let negative_step = Nco::<f32>::phase_step_from_frequency(-250.0, 1000.0);
-        assert_eq!(negative_step, -0x4000_0000);
-
-        assert_abs_diff_eq!(
-            Nco::<f32>::frequency_from_phase_step(step, 1000.0),
-            250.0,
-            epsilon = EPS
-        );
-    }
-
-    #[test]
     fn config_from_frequency_sets_phase_step() {
         let config = Config::<f32>::from_frequency(125.0, 1000.0);
 
@@ -723,55 +668,6 @@ mod tests {
         assert_eq!(nco.phase(), 0);
     }
 
-    #[test]
-    fn frequency_from_phase_step_keeps_the_product_order() {
-        // The product forms before the scale divides it, so a large step against a large sample rate
-        // reaches infinity. Pinned so the expression is not reassociated: dividing by the scale first
-        // would return a finite value here and silently change what this has always returned.
-        assert!(Nco::<f32>::frequency_from_phase_step(i32::MAX, 1.0e30).is_infinite());
-        assert_abs_diff_eq!(
-            Nco::<f32>::frequency_from_phase_step(0x4000_0000, 1000.0),
-            250.0,
-            epsilon = EPS
-        );
-    }
-
-    #[test]
-    fn frequency_and_turns_spellings_agree_on_the_same_rate() {
-        // Ratios that are not whole fractions of a turn, so the two paths would diverge if either
-        // folded or truncated differently.
-        for &(frequency_hz, sample_rate_hz) in
-            &[(7.3_f32, 48_000.0_f32), (-7.3, 48_000.0), (1.0, 7.0)]
-        {
-            assert_eq!(
-                Nco::<f32>::phase_step_from_frequency(frequency_hz, sample_rate_hz),
-                Nco::<f32>::phase_step_from_turns_per_sample(frequency_hz / sample_rate_hz)
-            );
-        }
-    }
-
-    #[test]
-    fn phase_step_from_frequency_truncates_towards_zero() {
-        // 7.3 / 48000 is 653192.53 phase words. Pinned because delegating to the turns helper must
-        // not change what this has always returned.
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(7.3, 48_000.0),
-            653_192
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(-7.3, 48_000.0),
-            -653_192
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(250.0, 1000.0),
-            0x4000_0000
-        );
-        // Both inputs are finite but their ratio overflows, which folds to `NaN` and casts to zero.
-        // Pinned because routing this through the checked helper would panic instead, and the
-        // documented contract promises a panic only for a non-finite input.
-        assert_eq!(Nco::<f32>::phase_step_from_frequency(3.0e38, 1.0e-38), 0);
-    }
-
     #[cfg(feature = "complex")]
     #[test]
     fn phasor_then_step_returns_the_current_phase_then_advances() {
@@ -787,6 +683,66 @@ mod tests {
             assert_eq!(got.im.to_bits(), expected.im.to_bits());
             assert_eq!(advancing.phase(), manual.phase());
         }
+    }
+
+    #[test]
+    fn every_conversion_delegates_to_math_phase() {
+        for turns in [0.0_f32, 0.1, 0.25, -0.3, 0.499, 1.75, -2.5] {
+            assert_eq!(
+                Nco::<f32>::phase_word_from_turns(turns),
+                math::phase::phase_word_from_turns(turns)
+            );
+            assert_eq!(
+                Nco::<f32>::phase_step_from_turns_per_sample(turns),
+                math::phase::phase_step_from_turns_per_sample(turns)
+            );
+            let radians = turns * core::f32::consts::TAU;
+            assert_eq!(
+                Nco::<f32>::phase_word_from_radians(radians),
+                math::phase::phase_word_from_radians(radians)
+            );
+            assert_eq!(
+                Nco::<f32>::phase_step_from_radians_per_sample(radians),
+                math::phase::phase_step_from_radians_per_sample(radians)
+            );
+        }
+        for step in [0_i32, 1, -1, i32::MAX, i32::MIN, 0x4000_0000] {
+            assert_eq!(
+                Nco::<f32>::turns_per_sample_from_phase_step(step).to_bits(),
+                math::phase::turns_per_sample_from_phase_step(step).to_bits()
+            );
+            assert_eq!(
+                Nco::<f32>::radians_per_sample_from_phase_step(step).to_bits(),
+                math::phase::radians_per_sample_from_phase_step(step).to_bits()
+            );
+            assert_eq!(
+                Nco::<f32>::frequency_from_phase_step(step, 48_000.0).to_bits(),
+                math::phase::frequency_from_phase_step(step, 48_000.0).to_bits()
+            );
+        }
+        for word in [0_u32, 1, 0x4000_0000, 0x8000_0000, 0xFFFF_FFFF] {
+            assert_eq!(
+                Nco::<f32>::turns_from_phase_word(word).to_bits(),
+                math::phase::turns_from_phase_word(word).to_bits()
+            );
+            assert_eq!(
+                Nco::<f32>::radians_from_phase_word(word).to_bits(),
+                math::phase::radians_from_phase_word(word).to_bits()
+            );
+        }
+        assert_eq!(
+            Nco::<f32>::phase_step_from_frequency(1000.0, 48_000.0),
+            math::phase::phase_step_from_frequency(1000.0, 48_000.0)
+        );
+    }
+
+    #[test]
+    fn from_turns_reads_back_its_own_rate() {
+        assert_abs_diff_eq!(
+            Nco::<f32>::from_turns(0.0, -0.125).turns_per_sample(),
+            -0.125,
+            epsilon = EPS
+        );
     }
 
     #[test]
@@ -819,84 +775,6 @@ mod tests {
 
         // A setter touches the rate only, never the accumulated phase.
         assert_eq!(nco.phase(), 0x1234_5678);
-    }
-
-    #[test]
-    fn turn_helpers_convert_whole_fractions_of_a_turn() {
-        // A whole fraction of a turn is a whole number of phase words, so these are exact.
-        assert_eq!(
-            Nco::<f32>::phase_step_from_turns_per_sample(0.25),
-            0x4000_0000
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_turns_per_sample(-0.25),
-            -0x4000_0000
-        );
-        assert_eq!(Nco::<f32>::phase_word_from_turns(-0.25), 0xC000_0000);
-        // Three quarters of a turn per sample aliases to a quarter turn backwards.
-        assert_eq!(
-            Nco::<f32>::phase_step_from_turns_per_sample(0.75),
-            -0x4000_0000
-        );
-
-        assert_abs_diff_eq!(
-            Nco::<f32>::turns_per_sample_from_phase_step(0x4000_0000),
-            0.25,
-            epsilon = EPS
-        );
-        assert_abs_diff_eq!(
-            Nco::<f32>::from_turns(0.0, -0.125).turns_per_sample(),
-            -0.125,
-            epsilon = EPS
-        );
-    }
-
-    #[test]
-    fn turns_and_radians_agree_on_the_same_rotation() {
-        let turns = 0.1_f32;
-
-        assert_eq!(
-            Nco::<f32>::phase_step_from_turns_per_sample(turns),
-            Nco::<f32>::phase_step_from_radians_per_sample(turns * core::f32::consts::TAU)
-        );
-    }
-
-    #[test]
-    fn radian_helpers_convert_whole_fractions_of_a_turn() {
-        use core::f32::consts::TAU;
-
-        // A whole fraction of a turn is a whole number of phase words, so these are exact.
-        assert_eq!(
-            Nco::<f32>::phase_step_from_radians_per_sample(TAU / 4.0),
-            0x4000_0000
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_radians_per_sample(-TAU / 4.0),
-            -0x4000_0000
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_radians_per_sample(TAU / 8.0),
-            0x2000_0000
-        );
-        assert_eq!(Nco::<f32>::phase_word_from_radians(TAU / 4.0), 0x4000_0000);
-        assert_eq!(Nco::<f32>::phase_word_from_radians(-TAU / 4.0), 0xC000_0000);
-
-        // Three quarters of a turn per sample aliases to a quarter turn backwards.
-        assert_eq!(
-            Nco::<f32>::phase_step_from_radians_per_sample(3.0 * TAU / 4.0),
-            -0x4000_0000
-        );
-
-        assert_abs_diff_eq!(
-            Nco::<f32>::radians_per_sample_from_phase_step(0x4000_0000),
-            TAU / 4.0,
-            epsilon = EPS
-        );
-        assert_abs_diff_eq!(
-            Nco::<f32>::radians_from_phase_word(0xC000_0000),
-            3.0 * TAU / 4.0,
-            epsilon = EPS
-        );
     }
 
     #[test]
@@ -933,30 +811,6 @@ mod tests {
         assert_eq!(
             Config::<f32>::from_radians_per_sample(rate).phase_step(),
             Nco::<f32>::phase_step_from_radians_per_sample(rate)
-        );
-    }
-
-    #[test]
-    fn nyquist_frequency_folds_to_negative_nyquist() {
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(500.0, 1000.0),
-            i32::MIN
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(-500.0, 1000.0),
-            i32::MIN
-        );
-    }
-
-    #[test]
-    fn frequency_aliases_fold_modulo_sample_rate() {
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(750.0, 1000.0),
-            -0x4000_0000
-        );
-        assert_eq!(
-            Nco::<f32>::phase_step_from_frequency(-750.0, 1000.0),
-            0x4000_0000
         );
     }
 


### PR DESCRIPTION
Nothing in the crate translated a signal in frequency, which is the most common thing an `Nco` is for. `Mixer` owns an oscillator and multiplies each sample by its phasor, implementing `Filter<Complex<T>>` like every other stateful filter here.

The phasor is `cos(phase) + j sin(phase)`, so mixing shifts up in frequency. Removing a carrier offset means giving the oscillator the negated rate, which is documented on the type and pinned by a test that a tone mixed with its own rate lands at twice it rather than at DC. A round trip alone would pass with a conjugated phasor.

`nco_mut` exposes the oscillator so a carrier-recovery loop can retune mid-stream. A rate change leaves the phase accumulator untouched, which a test pins.